### PR TITLE
Error Messages and RomFS refactor

### DIFF
--- a/Fushigi/Program.cs
+++ b/Fushigi/Program.cs
@@ -26,13 +26,13 @@ RomFS romFS = null;
 string errMsg = "";
 Vector4 errCol = new(0.95f, 0.14f, 0.14f, 1f);
 
-Course currentCourse = null;
+Course? currentCourse = null;
 
 window.Load += () => WindowManager.RegisterRenderDelegate(window, DoRendering);
 
 void DoFill()
 {
-    foreach (KeyValuePair<string, string[]> worldCourses in romFS.GetCourseEntries())
+    foreach (KeyValuePair<string, string[]> worldCourses in romFS!.GetCourseEntries())
     {
         if (ImGui.TreeNode(worldCourses.Key))
         {
@@ -63,7 +63,7 @@ void DoFill()
 void DoAreaSelect()
 {
     bool status = ImGui.Begin("Area Select");
-    int areaCount = currentCourse.GetAreaCount();
+    int areaCount = currentCourse!.GetAreaCount();
 
     for (int i = 0; i < areaCount; i++)
     {
@@ -84,11 +84,14 @@ void DoAreaParams()
 {
     bool status = ImGui.Begin("Course Area Parameters");
 
-    CourseArea area = currentCourse.GetArea(selectedArea);
-
-    // if the area is null, it means we just switched from another course to a new one
+    // if GetArea throws, it means we just switched from another course to a new one
     // so, we nullify the selected area until the user selects a new one
-    if (area == null)
+    CourseArea area;
+    try
+    {
+        area = currentCourse!.GetArea(selectedArea);
+    }
+    catch
     {
         selectedArea = "";
         return;
@@ -148,19 +151,19 @@ void DoAreaParams()
         {
             CourseArea.AreaParam.SkinParam skinParams = area.mAreaParams.mSkinParams;
 
-            if (area.mAreaParams.ContainsSkinParam("FieldA"))
+            if (skinParams.mFieldA != null)
             {
                 byte[] fielda_buf = Encoding.ASCII.GetBytes(skinParams.mFieldA);
                 ImGui.InputText("FieldA", fielda_buf, (uint)fielda_buf.Length);
             }
 
-            if (area.mAreaParams.ContainsSkinParam("FieldB"))
+            if (skinParams.mFieldB != null)
             {
-                byte[] buf = Encoding.ASCII.GetBytes(skinParams.mFieldA);
+                byte[] buf = Encoding.ASCII.GetBytes(skinParams.mFieldB);
                 ImGui.InputText("FieldB", buf, (uint)buf.Length);
             }
 
-            if (area.mAreaParams.ContainsSkinParam("Object"))
+            if (skinParams.mObject != null)
             {
                 byte[] buf = Encoding.ASCII.GetBytes(skinParams.mObject);
                 ImGui.InputText("Object", buf, (uint)buf.Length);

--- a/Fushigi/Program.cs
+++ b/Fushigi/Program.cs
@@ -43,15 +43,14 @@ void DoFill()
                 {
                     try
                     {
-                        currentCourse = new Course(courseLocation, romFS);
+                        currentCourse = new(courseLocation, romFS);
                         _courseSelected = true;
                         errMsg = "";
                     }
                     catch (Exception ex)
                     {
-                        errMsg = ex.Message;
+                        ImGui.TextColored(errCol, $"Error loading course: {ex.Message}");
                     }
-
                     ImGui.TreePop();
                 }
             }

--- a/Fushigi/Program.cs
+++ b/Fushigi/Program.cs
@@ -21,8 +21,6 @@ bool _courseSelected = false;
 string selectedStage = "";
 string selectedArea = "";
 
-RomFS romFS = null;
-
 string errMsg = "";
 Vector4 errCol = new(0.95f, 0.14f, 0.14f, 1f);
 
@@ -32,7 +30,7 @@ window.Load += () => WindowManager.RegisterRenderDelegate(window, DoRendering);
 
 void DoFill()
 {
-    foreach (KeyValuePair<string, string[]> worldCourses in romFS!.GetCourseEntries())
+    foreach (KeyValuePair<string, string[]> worldCourses in RomFS.GetCourseEntries())
     {
         if (ImGui.TreeNode(worldCourses.Key))
         {
@@ -43,7 +41,7 @@ void DoFill()
                 {
                     try
                     {
-                        currentCourse = new(courseLocation, romFS);
+                        currentCourse = new(courseLocation);
                         _courseSelected = true;
                         errMsg = "";
                     }
@@ -210,7 +208,7 @@ void DoRendering(GL gl, double delta, ImGuiController controller)
         {
             try
             {
-                romFS = new(basePath);
+                RomFS.setRoot(basePath);
                 _stageList = true;
                 errMsg = "";
             }

--- a/Fushigi/RomFS.cs
+++ b/Fushigi/RomFS.cs
@@ -10,31 +10,31 @@ namespace Fushigi
 {
     public class RomFS
     {
-        private string _rootPath;
-        private Dictionary<string, string[]> _courseEntries;
+        private static string _sRootPath = "";
+        private static Dictionary<string, string[]> _sCourseEntries = [];
 
-        public RomFS(string rootPath)
+        public static void setRoot(string rootPath)
         {
-            _rootPath = rootPath;
-            _courseEntries = CacheCourseFiles();
+            _sRootPath = rootPath;
+            _sCourseEntries = CacheCourseFiles();
         }
 
-        public string GetRoot()
+        public static string GetRoot()
         {
-            return _rootPath;
+            return _sRootPath;
         }
 
-        public Dictionary<string, string[]> GetCourseEntries()
+        public static Dictionary<string, string[]> GetCourseEntries()
         {
-            return _courseEntries;
+            return _sCourseEntries;
         }
 
-        public Course GetCourse(string courseName)
+        public static Course GetCourse(string courseName)
         {
-            return new Course(courseName, this);
+            return new Course(courseName);
         }
 
-        private Dictionary<string, string[]> CacheCourseFiles()
+        private static Dictionary<string, string[]> CacheCourseFiles()
         {
             /* common paths to check */
             if (!DirectoryExists("BancMapUnit") || !DirectoryExists("Model") || !DirectoryExists("Stage"))
@@ -71,18 +71,18 @@ namespace Fushigi
             return courseEntries;
         }
 
-        private bool DirectoryExists(string path) {
-            return Directory.Exists($"{_rootPath}/{path}");
+        private static bool DirectoryExists(string path) {
+            return Directory.Exists($"{_sRootPath}/{path}");
         }
 
-        private string[] GetFiles(string path)
+        private static string[] GetFiles(string path)
         {
-            return Directory.GetFiles($"{_rootPath}/{path}");
+            return Directory.GetFiles($"{_sRootPath}/{path}");
         }
 
-        public byte[] GetFileBytes(string path)
+        public static byte[] GetFileBytes(string path)
         {
-            return File.ReadAllBytes($"{_rootPath}/{path}");
+            return File.ReadAllBytes($"{_sRootPath}/{path}");
         }
     }
 }

--- a/Fushigi/course/Course.cs
+++ b/Fushigi/course/Course.cs
@@ -15,16 +15,17 @@ namespace Fushigi.course
 {
     public class Course
     {
-        public Course(string courseName)
+        public Course(string courseName, RomFS romFS)
         {
             mCourseName = courseName;
             mAreas = new List<CourseArea>();
-            LoadFromRomFS();
+            mRomFs = romFS;
+            LoadFromRomFS();   
         }
 
         public void LoadFromRomFS()
         {
-            byte[] courseBytes = RomFS.GetFileBytes($"BancMapUnit/{mCourseName}.bcett.byml.zs");
+            byte[] courseBytes = mRomFs.GetFileBytes($"BancMapUnit/{mCourseName}.bcett.byml.zs");
             /* grab our course information file */
             Byml.Byml courseInfo = new Byml.Byml(new MemoryStream(FileUtil.DecompressData(courseBytes)));
 
@@ -35,7 +36,7 @@ namespace Fushigi.course
             {
                 string stageParamPath = ((BymlNode<string>)stageList[i]).Data.Replace("Work/", "").Replace(".gyml", ".bgyml");
                 string stageName = Path.GetFileName(stageParamPath).Split(".game")[0];
-                mAreas.Add(new CourseArea(stageName));
+                mAreas.Add(new CourseArea(stageName, mRomFs));
             }
         }
 
@@ -64,5 +65,6 @@ namespace Fushigi.course
 
         string mCourseName;
         List<CourseArea> mAreas;
+        private RomFS mRomFs;
     }
 }

--- a/Fushigi/course/Course.cs
+++ b/Fushigi/course/Course.cs
@@ -15,17 +15,16 @@ namespace Fushigi.course
 {
     public class Course
     {
-        public Course(string courseName, RomFS romFS)
+        public Course(string courseName)
         {
             mCourseName = courseName;
             mAreas = new List<CourseArea>();
-            mRomFs = romFS;
             LoadFromRomFS();   
         }
 
         public void LoadFromRomFS()
         {
-            byte[] courseBytes = mRomFs.GetFileBytes($"BancMapUnit/{mCourseName}.bcett.byml.zs");
+            byte[] courseBytes = RomFS.GetFileBytes($"BancMapUnit/{mCourseName}.bcett.byml.zs");
             /* grab our course information file */
             Byml.Byml courseInfo = new Byml.Byml(new MemoryStream(FileUtil.DecompressData(courseBytes)));
 
@@ -36,7 +35,7 @@ namespace Fushigi.course
             {
                 string stageParamPath = ((BymlNode<string>)stageList[i]).Data.Replace("Work/", "").Replace(".gyml", ".bgyml");
                 string stageName = Path.GetFileName(stageParamPath).Split(".game")[0];
-                mAreas.Add(new CourseArea(stageName, mRomFs));
+                mAreas.Add(new CourseArea(stageName));
             }
         }
 
@@ -65,6 +64,5 @@ namespace Fushigi.course
 
         string mCourseName;
         List<CourseArea> mAreas;
-        private RomFS mRomFs;
     }
 }

--- a/Fushigi/course/Course.cs
+++ b/Fushigi/course/Course.cs
@@ -55,7 +55,7 @@ namespace Fushigi.course
                 }
             }
 
-            return null;
+            throw new Exception($"GetArea() -- No Area with name {name} found");
         }
 
         public int GetAreaCount()

--- a/Fushigi/course/CourseArea.cs
+++ b/Fushigi/course/CourseArea.cs
@@ -11,14 +11,13 @@ namespace Fushigi.course
 {
     public class CourseArea
     {
+        string mAreaName;
+        private RomFS mRomFS;
+        public AreaParam mAreaParams;
+
         public CourseArea(string areaName, RomFS romFS) {
             mAreaName = areaName;
             mRomFS = romFS;
-            Load();
-        }
-
-        public void Load()
-        {
             mAreaParams = new AreaParam(
                 new Byml.Byml(
                     new MemoryStream(
@@ -31,11 +30,7 @@ namespace Fushigi.course
         public string GetName()
         {
             return mAreaName;
-        }
-
-        string mAreaName;
-        private RomFS mRomFS;
-        public AreaParam mAreaParams;
+        }    
 
         public class AreaParam
         {
@@ -152,9 +147,9 @@ namespace Fushigi.course
             public class SkinParam
             {
                 public bool mDisableBgUnitDecoA;
-                public string mFieldA;
-                public string mFieldB;
-                public string mObject;
+                public string? mFieldA;
+                public string? mFieldB;
+                public string? mObject;
             }
 
             Byml.Byml mByml;
@@ -165,7 +160,7 @@ namespace Fushigi.course
             public bool mIsNotCallWaterEnvSE;
             public float mWonderBGMStartOffset;
             public string mWonderBGMType;
-            public SkinParam mSkinParams;
+            public SkinParam? mSkinParams;
         }
     }
 }

--- a/Fushigi/course/CourseArea.cs
+++ b/Fushigi/course/CourseArea.cs
@@ -12,16 +12,14 @@ namespace Fushigi.course
     public class CourseArea
     {
         string mAreaName;
-        private RomFS mRomFS;
         public AreaParam mAreaParams;
 
-        public CourseArea(string areaName, RomFS romFS) {
+        public CourseArea(string areaName) {
             mAreaName = areaName;
-            mRomFS = romFS;
             mAreaParams = new AreaParam(
                 new Byml.Byml(
                     new MemoryStream(
-                        mRomFS.GetFileBytes($"Stage/AreaParam/{mAreaName}.game__stage__AreaParam.bgyml")
+                        RomFS.GetFileBytes($"Stage/AreaParam/{mAreaName}.game__stage__AreaParam.bgyml")
                     )
                 )
             );

--- a/Fushigi/course/CourseArea.cs
+++ b/Fushigi/course/CourseArea.cs
@@ -11,15 +11,21 @@ namespace Fushigi.course
 {
     public class CourseArea
     {
-        public CourseArea(string areaName) {
+        public CourseArea(string areaName, RomFS romFS) {
             mAreaName = areaName;
+            mRomFS = romFS;
             Load();
         }
 
         public void Load()
         {
-            string areaParamPath = $"{RomFS.GetRoot()}/Stage/AreaParam/{mAreaName}.game__stage__AreaParam.bgyml";
-            mAreaParams = new AreaParam(new Byml.Byml(new MemoryStream(File.ReadAllBytes(areaParamPath))));
+            mAreaParams = new AreaParam(
+                new Byml.Byml(
+                    new MemoryStream(
+                        mRomFS.GetFileBytes($"Stage/AreaParam/{mAreaName}.game__stage__AreaParam.bgyml")
+                    )
+                )
+            );
         }
 
         public string GetName()
@@ -28,6 +34,7 @@ namespace Fushigi.course
         }
 
         string mAreaName;
+        private RomFS mRomFS;
         public AreaParam mAreaParams;
 
         public class AreaParam


### PR DESCRIPTION
This PR aims to set the project on a path to avoid technical debt moving forwards, as well as add some error messaging rather than throwing exceptions to crash the app.

The RomFS class has been refactored to act as an API for the romfs directory. All interaction with this directory is done through this class from now on. The design is not perfect, if this class could be some sort of singleton, that would be ideal. But there isn't a nice way to do a singleton with parameters. So right now an instance is created in Program.cs and the reference is passed around from there wherever needed.

The reason for this refactor is to unify where the File I/O is happening. The way that the RomFS class was going previously made me very anxious, and I could foresee a lot of issues in the future with people accessing the file systems in different ways across the board. This should comply further with SOLID.

As far as error messages go, take a look at some screenshots:
![image](https://github.com/shibbo/Fushigi/assets/92652573/51f1a7e4-b17a-4ab2-a58c-fe73a8d9a7ed)
![image](https://github.com/shibbo/Fushigi/assets/92652573/1822bd59-0a03-4083-afb4-0addfadc4b67)

These should be nicer than the whole app just crashing on you. Of course these error messages can be easily changed and moved around to your liking.

I want to mention that I think we are going to have to find some more clever ways to render the app moving forward. I like Tomatech's method of caching the courses in a variable, we should take that idea and run with it for a lot more things in the app.