### PR TITLE
Clean Program.cs and add radio select courses

### DIFF
--- a/Fushigi/Program.cs
+++ b/Fushigi/Program.cs
@@ -41,9 +41,8 @@ void DoFill()
     {
         if (ImGui.TreeNode(worldCourses.Key))
         {
-            for (int i = 0; i < worldCourses.Value.Length; i++)
+            foreach (var courseLocation in worldCourses.Value)
             {
-                string courseLocation = worldCourses.Value[i];
                 if (ImGui.TreeNodeEx(courseLocation))
                 {
                     if (currentCourse == null || currentCourse.GetName() != courseLocation)

--- a/Fushigi/Program.cs
+++ b/Fushigi/Program.cs
@@ -45,7 +45,11 @@ void DoFill()
         {
             foreach (var courseLocation in worldCourses.Value)
             {
-                if (ImGui.TreeNodeEx(courseLocation))
+                if (ImGui.RadioButton(
+                        courseLocation,
+                        currentCourse == null ? false : courseLocation == currentCourse.GetName()
+                    )
+                )
                 {
                     if (currentCourse == null || currentCourse.GetName() != courseLocation)
                     {
@@ -64,6 +68,11 @@ void DoFill()
 void DoActorLoad()
 {
     CourseArea area = currentCourse.GetArea(selectedArea);
+    if (area == null)
+    {
+        return;
+    }
+
     var root = area.GetRootNode();
 
     bool actorStatus = ImGui.Begin("Actors");

--- a/Fushigi/Program.cs
+++ b/Fushigi/Program.cs
@@ -208,11 +208,9 @@ void DoActorLoad()
 void DoAreaSelect()
 {
     bool status = ImGui.Begin("Area Select");
-    int areaCount = currentCourse.GetAreaCount();
 
-    for (int i = 0; i < areaCount; i++)
+    foreach (var area in currentCourse.GetAreas())
     {
-        CourseArea area = currentCourse.GetArea(i);
         if (ImGui.Selectable(area.GetName()))
         {
             if (selectedArea != area.GetName())

--- a/Fushigi/Program.cs
+++ b/Fushigi/Program.cs
@@ -25,7 +25,6 @@ bool _courseSelected = false;
 bool _loadActors = false;
 string selectedStage = "";
 string selectedArea = "";
-Dictionary<string, string[]> courseEntries = [];
 Vector2 areaScenePan = new();
 float areaSceneZoom = 1;
 
@@ -36,35 +35,6 @@ ParamLoader.Load();
 
 window.Load += () => WindowManager.RegisterRenderDelegate(window, DoRendering);
 
-void CacheCourseFiles()
-{
-    courseEntries.Clear();
-    string[] loadFiles = RomFS.GetFiles("/Stage/WorldMapInfo");
-    foreach (string loadFile in loadFiles)
-    {
-        string worldName = Path.GetFileName(loadFile).Split(".game")[0];
-        List<string> courseLocationList = new();
-        Byml byml = new Byml(new MemoryStream(File.ReadAllBytes(loadFile)));
-        var root = (BymlHashTable)byml.Root;
-        var courseList = (BymlArrayNode)root["CourseTable"];
-
-        for (int i = 0; i < courseList.Length; i++)
-        {
-            var course = (BymlHashTable)courseList[i];
-            string derp = ((BymlNode<string>)course["StagePath"]).Data;
-
-            // we need to "fix" our StagePath so it points to our course
-            string courseLocation = Path.GetFileName(derp).Split(".game")[0];
-
-            courseLocationList.Add(courseLocation);
-        }
-        if (!courseEntries.ContainsKey(worldName))
-        {
-            courseEntries.Add(worldName, courseLocationList.ToArray());
-        }
-    }
-}
-
 void DoFill()
 {
     /* common paths to check */
@@ -73,7 +43,7 @@ void DoFill()
         throw new Exception("DoRendering() -- Required folders not found.");
     }
 
-    foreach (KeyValuePair<string, string[]> worldCourses in courseEntries)
+    foreach (KeyValuePair<string, string[]> worldCourses in RomFS.GetCourseEntries())
     {
         if (ImGui.TreeNode(worldCourses.Key))
         {
@@ -444,13 +414,11 @@ void DoRendering(GL gl, double delta, ImGuiController controller)
     {
         string basePath = System.Text.Encoding.ASCII.GetString(folderBytes).Replace("\0", "");
         if (string.IsNullOrEmpty(basePath))
-            basePath = "D:\\Hacking\\Switch\\Wonder\\romfs";
-
-        RomFS.SetRoot(basePath);
+            basePath = "D:\\Hacking\\Switch\\Wonder\\romfs";     
 
         if (Path.Exists(basePath))
         {
-            CacheCourseFiles();
+            RomFS.SetRoot(basePath);
 
             if (!ParamDB.sIsInit)
             {

--- a/Fushigi/Program.cs
+++ b/Fushigi/Program.cs
@@ -37,12 +37,6 @@ window.Load += () => WindowManager.RegisterRenderDelegate(window, DoRendering);
 
 void DoFill()
 {
-    /* common paths to check */
-    if (!RomFS.DirectoryExists("BancMapUnit") || !RomFS.DirectoryExists("Model") || !RomFS.DirectoryExists("Stage"))
-    {
-        throw new Exception("DoRendering() -- Required folders not found.");
-    }
-
     foreach (KeyValuePair<string, string[]> worldCourses in RomFS.GetCourseEntries())
     {
         if (ImGui.TreeNode(worldCourses.Key))

--- a/Fushigi/RomFS.cs
+++ b/Fushigi/RomFS.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Fushigi.Byml;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,11 +12,17 @@ namespace Fushigi
         public static void SetRoot(string root)
         {
             sRomFSRoot = root;
+            CacheCourseFiles();
         }
 
         public static string GetRoot()
         {
             return sRomFSRoot;
+        }
+
+        public static Dictionary<string, string[]> GetCourseEntries()
+        {
+            return sCourseEntries;
         }
 
         public static bool DirectoryExists(string path) {
@@ -32,6 +39,36 @@ namespace Fushigi
             return File.ReadAllBytes($"{sRomFSRoot}/{path}");
         }
 
+        private static void CacheCourseFiles()
+        {
+            sCourseEntries.Clear();
+            string[] loadFiles = RomFS.GetFiles("/Stage/WorldMapInfo");
+            foreach (string loadFile in loadFiles)
+            {
+                string worldName = Path.GetFileName(loadFile).Split(".game")[0];
+                List<string> courseLocationList = new();
+                Byml.Byml byml = new Byml.Byml(new MemoryStream(File.ReadAllBytes(loadFile)));
+                var root = (BymlHashTable)byml.Root;
+                var courseList = (BymlArrayNode)root["CourseTable"];
+
+                for (int i = 0; i < courseList.Length; i++)
+                {
+                    var course = (BymlHashTable)courseList[i];
+                    string derp = ((BymlNode<string>)course["StagePath"]).Data;
+
+                    // we need to "fix" our StagePath so it points to our course
+                    string courseLocation = Path.GetFileName(derp).Split(".game")[0];
+
+                    courseLocationList.Add(courseLocation);
+                }
+                if (!sCourseEntries.ContainsKey(worldName))
+                {
+                    sCourseEntries.Add(worldName, courseLocationList.ToArray());
+                }
+            }
+        }
+
         private static string sRomFSRoot;
+        private static Dictionary<string, string[]> sCourseEntries = [];
     }
 }

--- a/Fushigi/RomFS.cs
+++ b/Fushigi/RomFS.cs
@@ -12,6 +12,13 @@ namespace Fushigi
         public static void SetRoot(string root)
         {
             sRomFSRoot = root;
+
+            /* common paths to check */
+            if (!RomFS.DirectoryExists("BancMapUnit") || !RomFS.DirectoryExists("Model") || !RomFS.DirectoryExists("Stage"))
+            {
+                throw new Exception("DoRendering() -- Required folders not found.");
+            }
+
             CacheCourseFiles();
         }
 

--- a/Fushigi/course/Course.cs
+++ b/Fushigi/course/Course.cs
@@ -44,6 +44,11 @@ namespace Fushigi.course
             }
         }
 
+        public List<CourseArea> GetAreas()
+        {
+            return mAreas;
+        }
+
         public CourseArea GetArea(int idx)
         {
             return mAreas.ElementAt(idx);

--- a/Fushigi/ui/widgets/AreaScene.cs
+++ b/Fushigi/ui/widgets/AreaScene.cs
@@ -1,0 +1,167 @@
+﻿using Fushigi.Byml;
+using Fushigi.course;
+using ImGuiNET;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fushigi.ui.widgets
+{
+    class AreaScene
+    {
+        CourseArea area;
+
+        private const int gridBasePixelsPerUnit = 32;
+
+        ImDrawListPtr drawList;
+
+        Vector2 areaScenePan = new();
+        float areaSceneZoom = 1;
+        float gridPixelsPerUnit;
+
+        //canvas viewport coordinates
+        Vector2 canvasMin;
+        Vector2 canvasSize;
+        Vector2 canvasMax;
+        Vector2 canvasMidpoint;
+
+        Vector2 panOrigin;
+
+        public AreaScene(CourseArea area)
+        {
+            this.area = area;
+        }
+
+        public void DisplayArea()
+        {
+            bool status = ImGui.Begin("Course Area");
+
+            UpdateCanvasSizes();
+
+            drawList = ImGui.GetWindowDrawList();
+
+            //canvas background
+            drawList.AddRectFilled(canvasMin, canvasMax, 0xFF323232);
+
+            //controls
+            HandleIO();
+
+            //grid lines
+            GridLines();
+
+            //level
+            PopulateArea();
+
+            drawList.AddRect(canvasMin, canvasMax, 0xFFFFFFFF);
+            if (status)
+            {
+                ImGui.End();
+            }
+        }
+
+        private void UpdateCanvasSizes()
+        {
+            canvasSize = Vector2.Max(ImGui.GetContentRegionAvail(), new Vector2(50, 50));
+            canvasMin = ImGui.GetCursorScreenPos();
+            canvasMax = canvasMin + canvasSize;
+            canvasMidpoint = canvasMin + (canvasSize * new Vector2(0.5f));
+        }
+
+        private void HandleIO()
+        {
+            ImGuiIOPtr io = ImGui.GetIO();
+
+            //mouse hover and click detection
+            ImGui.InvisibleButton("canvas", canvasSize, ImGuiButtonFlags.MouseButtonLeft | ImGuiButtonFlags.MouseButtonRight | ImGuiButtonFlags.MouseButtonMiddle);
+            bool mouseHover = ImGui.IsItemHovered();
+            bool mouseActive = ImGui.IsItemActive();
+
+            // panning with middle mouse click
+            if (mouseActive && ImGui.IsMouseDragging(ImGuiMouseButton.Middle))
+            {
+                areaScenePan += io.MouseDelta;
+            }
+            panOrigin = canvasMidpoint + areaScenePan;
+
+            // zooming with scroll wheel
+            if (mouseHover && io.MouseWheel != 0)
+            {
+                Vector2 prevMouseGridCoordinates = (io.MousePos - panOrigin) / new Vector2(gridBasePixelsPerUnit * areaSceneZoom);
+                areaSceneZoom += io.MouseWheel * 0.1f * areaSceneZoom;
+                areaSceneZoom = MathF.Max(MathF.Min(areaSceneZoom, 5), 0.1f);
+                Vector2 newMouseGridCoordinates = (io.MousePos - panOrigin) / new Vector2(gridBasePixelsPerUnit * areaSceneZoom);
+                areaScenePan += (newMouseGridCoordinates - prevMouseGridCoordinates) * new Vector2(gridBasePixelsPerUnit * areaSceneZoom);
+                panOrigin = canvasMidpoint + areaScenePan;
+            }
+            gridPixelsPerUnit = gridBasePixelsPerUnit * areaSceneZoom;
+        }
+
+        private void GridLines()
+        {
+            drawList.PushClipRect(canvasMin, canvasMax, true);
+
+            Vector2 gridStart = (canvasSize * new Vector2(0.5f)) + areaScenePan;
+            for (float x = gridStart.X % gridPixelsPerUnit; x < canvasSize.X; x += gridPixelsPerUnit)
+            {
+                drawList.AddLine(new Vector2(canvasMin.X + x, canvasMin.Y), new Vector2(canvasMin.X + x, canvasMax.Y), MathF.Abs((canvasMin.X + x) - panOrigin.X) < 0.01 ? 0xFF008000 : 0xFF505050);
+            }
+            for (float y = gridStart.Y % gridPixelsPerUnit; y < canvasSize.Y; y += gridPixelsPerUnit)
+            {
+                drawList.AddLine(new Vector2(canvasMin.X, canvasMin.Y + y), new Vector2(canvasMax.X, canvasMin.Y + y), MathF.Abs((canvasMin.Y + y) - panOrigin.Y) < 0.01 ? 0xFF000080 : 0xFF505050);
+            }
+        }
+
+        private void PopulateArea()
+        {
+            var root = area.GetRootNode();
+
+            //BgUnits are in an array.
+            BymlArrayNode bgUnitsArray = (BymlArrayNode)((BymlHashTable)root)["BgUnits"];
+            foreach (BymlHashTable bgUnit in bgUnitsArray.Array)
+            {
+                BymlArrayNode wallsArray = (BymlArrayNode)((BymlHashTable)bgUnit)["Walls"];
+
+                foreach (BymlHashTable walls in wallsArray.Array)
+                {
+                    BymlHashTable externalRail = (BymlHashTable)walls["ExternalRail"];
+                    BymlArrayNode pointsArray = (BymlArrayNode)externalRail["Points"];
+                    List<Vector2> pointsList = new();
+                    foreach (BymlHashTable points in pointsArray.Array)
+                    {
+                        var pos = (BymlArrayNode)points["Translate"];
+                        float x = ((BymlNode<float>)pos[0]).Data;
+                        float y = ((BymlNode<float>)pos[1]).Data;
+                        addPoint(new Vector2(x, y), 0xFFFFFFFF);
+                        pointsList.Add(new Vector2(x, y));
+                    }
+                    for (int i = 0; i < pointsList.Count - 1; i++)
+                    {
+                        drawLine(pointsList[i], pointsList[i + 1], 0xFFFFFFFF);
+                    }
+                    bool isClosed = ((BymlNode<bool>)externalRail["IsClosed"]).Data;
+                    if (isClosed)
+                    {
+                        drawLine(pointsList[pointsList.Count - 1], pointsList[0], 0xFFFFFFFF);
+                    }
+                }
+            }
+        }
+
+        private void addPoint(Vector2 gridPos, uint colour)
+        {
+            Vector2 modPos = panOrigin + (gridPos * new Vector2(gridPixelsPerUnit, -gridPixelsPerUnit));
+            drawList.AddCircleFilled(modPos, 2, colour);
+            //drawList.AddText(modPos, 0xFFFFFFFF, gridPos.ToString());
+        }
+
+        private void drawLine(Vector2 gridPos1, Vector2 gridPos2, uint colour)
+        {
+            Vector2 modPos1 = panOrigin + (gridPos1 * new Vector2(gridPixelsPerUnit, -gridPixelsPerUnit));
+            Vector2 modPos2 = panOrigin + (gridPos2 * new Vector2(gridPixelsPerUnit, -gridPixelsPerUnit));
+            drawList.AddLine(modPos1, modPos2, colour);
+        }
+    }
+}


### PR DESCRIPTION
# Program.cs Cleaning
- CacheCourseFiles moved to RomFs.cs
- DoAreaScene moved and modularized in new AreaScene.cs
- Miscellaneous readability reformats (changing some for loops to foreach)

# Course nodes changed to radio selection
- Allows one course to be selected at a time, saving performance on creating Course objects for courses that aren't being displayed (significant improvement from when users had multiple courses selected)
- Fixes a crash that occurred when switching levels while the area map/actor list was opened

![image](https://github.com/shibbo/Fushigi/assets/92652573/c498854d-31b9-4788-9722-2c4a2b4baec1)