### PR TITLE
Fix byml writing big data types.

### DIFF
--- a/Fushigi.Byml/BymlBigDataNode.cs
+++ b/Fushigi.Byml/BymlBigDataNode.cs
@@ -3,14 +3,14 @@
     public class BymlBigDataNode<T> : IBymlNode
     {
         public BymlNodeId Id { get; }
-        public T Value { get; }
+        public T Data { get; }
 
         public BymlBigDataNode(BymlNodeId id, BinaryReader reader, Func<BinaryReader, T> valueReader)
         {
             Id = id;
             using (reader.BaseStream.TemporarySeek(reader.ReadUInt32(), SeekOrigin.Begin))
             {
-                Value = valueReader(reader);
+                Data = valueReader(reader);
             }
         }
     }

--- a/Fushigi.Byml/BymlWriter.cs
+++ b/Fushigi.Byml/BymlWriter.cs
@@ -335,7 +335,7 @@ namespace Fushigi.Byml
             BymlHeader header = new()
             {
                 Magic = 0x4259,
-                Version = 4,
+                Version = 7,
                 HashKeyOffset = HashKeyStringTable.IsEmpty() ? 0 : hashKeyOffset,
                 StringTableOffset = StringTable.IsEmpty() ? 0 : stringTableOffset,
                 RootOrPathArrayOffset = rootOrPathArrayOffset

--- a/Fushigi.Byml/Utils.cs
+++ b/Fushigi.Byml/Utils.cs
@@ -160,7 +160,7 @@ namespace Fushigi.Byml
 
         public static T GetBigValue<T>(this IBymlNode bymlNode)
         {
-            return ((BymlBigDataNode<T>)bymlNode).Value;
+            return ((BymlBigDataNode<T>)bymlNode).Data;
         }
     }
 }

--- a/Fushigi.Byml/Writer/BymlBigDataList.cs
+++ b/Fushigi.Byml/Writer/BymlBigDataList.cs
@@ -29,7 +29,7 @@
         {
             foreach(var data in Internal)
             {
-                using (stream.TemporarySeek())
+                using (stream.TemporarySeek(data.Offset, SeekOrigin.Begin))
                     data.WriteBigData(stream);
                 stream.Position += data.CalcBigDataSize();
             }

--- a/Fushigi/Program.cs
+++ b/Fushigi/Program.cs
@@ -109,7 +109,7 @@ void DoActorLoad()
     foreach (BymlHashTable node in actorArray.Array)
     {
         string actorName = ((BymlNode<string>)node["Gyaml"]).Data;
-        ulong hash = ((BymlBigDataNode<ulong>)node["Hash"]).Value;
+        ulong hash = ((BymlBigDataNode<ulong>)node["Hash"]).Data;
 
         ImGui.PushID(hash.ToString());
         if (ImGui.TreeNode(actorName))
@@ -177,7 +177,7 @@ void DoActorLoad()
                                         ImGui.InputText(pair.Key, buf, (uint)buf.Length);
                                         break;*/
                                     case "F64":
-                                        double val = ((BymlBigDataNode<double>)paramNode).Value;
+                                        double val = ((BymlBigDataNode<double>)paramNode).Data;
                                         ImGui.InputDouble(pair.Key, ref val);
                                         break;
                                 }


### PR DESCRIPTION
This fixes the data not being seeked correctly when writing the data and also a casting error as it expects IBymlNode to have the value obtained by the "Data" property.. 
The default byml version is also now set to 7. 