### PR TITLE
Enable Docking to Viewport

### DIFF
--- a/Fushigi/ui/MainWindow.cs
+++ b/Fushigi/ui/MainWindow.cs
@@ -72,6 +72,7 @@ namespace Fushigi.ui
         public void Render(GL gl, double delta, ImGuiController controller)
         {
             ImGui.GetIO().ConfigFlags |= ImGuiConfigFlags.DockingEnable;
+            ImGui.DockSpaceOverViewport();
             
             /* this creates the viewport in the background */
             gl.Viewport(mWindow.FramebufferSize);


### PR DESCRIPTION
Allows for Windows do be docked to the edges of the Viewport and thus make better usage of the space

![Screenshot 2023-10-30 113913](https://github.com/shibbo/Fushigi/assets/43097559/0358604c-92ff-4bfe-83d8-0ce8e877bd75)
