### PR TITLE
Adjust the menu to use disabled save text when course is not loaded

### DIFF
--- a/Fushigi/ui/MainWindow.cs
+++ b/Fushigi/ui/MainWindow.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Fushigi.param;
 using Fushigi.ui.widgets;
 using ImGuiNET;
+using System.Numerics;
 
 namespace Fushigi.ui
 {
@@ -115,19 +116,25 @@ namespace Fushigi.ui
                     }
 
                     /* Saves the currently loaded course */
-                    if (mSelectedCourseScene != null)
+
+                    var text_color = mSelectedCourseScene == null ?
+                         ImGui.GetStyle().Colors[(int)ImGuiCol.TextDisabled] :
+                         ImGui.GetStyle().Colors[(int)ImGuiCol.Text];
+
+                    ImGui.PushStyleColor(ImGuiCol.Text, ImGui.ColorConvertFloat4ToU32(text_color));
+
+                    if (ImGui.MenuItem("Save") && mSelectedCourseScene != null)
                     {
-                        if (ImGui.MenuItem("Save"))
-                        {
-                            mSelectedCourseScene.Save();
-                        }
-                        if (ImGui.MenuItem("Save As"))
-                        {
-                            FolderDialog dlg = new FolderDialog();
-                            if (dlg.ShowDialog())
-                                mSelectedCourseScene.Save(dlg.SelectedPath);
-                        }
+                        mSelectedCourseScene.Save();
                     }
+                    if (ImGui.MenuItem("Save As") && mSelectedCourseScene != null)
+                    {
+                        FolderDialog dlg = new FolderDialog();
+                        if (dlg.ShowDialog())
+                            mSelectedCourseScene.Save(dlg.SelectedPath);
+                    }
+
+                    ImGui.PopStyleColor();
 
                     /* a ImGUI menu item that just closes the application */
                     if (ImGui.MenuItem("Close"))


### PR DESCRIPTION
Makes save menus grayed out rather than not being visible when a course is loaded. 

![image](https://github.com/shibbo/Fushigi/assets/13475262/6c777ac5-1ee7-4dc6-ad65-a6eac755ab16)