### PR TITLE
Change Course Selection Flow

### DIFF
--- a/Fushigi/ui/MainWindow.cs
+++ b/Fushigi/ui/MainWindow.cs
@@ -140,6 +140,16 @@ namespace Fushigi.ui
             }
         }
 
+        void DrawWelcome()
+        {
+            if (ImGui.Begin("Welcome"))
+            {
+                ImGui.Text("Welcome to Fushigi! Visit 'File->Set RomFS Path' to get started.");
+
+                ImGui.End();
+            }
+        }
+
         public void Render(GL gl, double delta, ImGuiController controller)
         {
             /* keep OpenGLs viewport size in sync with the window's size */
@@ -165,6 +175,10 @@ namespace Fushigi.ui
                 } 
 
                 mSelectedCourseScene?.DrawUI();
+            }
+            else
+            {
+                DrawWelcome();
             }
 
             /* render our ImGUI controller */

--- a/Fushigi/ui/widgets/CourseScene.cs
+++ b/Fushigi/ui/widgets/CourseScene.cs
@@ -91,6 +91,13 @@ namespace Fushigi.ui.widgets
             {
                 if (ImGui.BeginTabItem(area.GetName()))
                 {
+                    // Unselect actor on tab change
+                    // This is so that users do not see an actor selected from another area
+                    if (selectedArea != area)
+                    {
+                        mSelectedActor = null;
+                    }
+
                     selectedArea = area;
 
                     ImGui.EndTabItem();
@@ -147,31 +154,34 @@ namespace Fushigi.ui.widgets
 
         private void ActorParameterPanel()
         {
-            if (mSelectedActor is null)
-            {
-                return;
-            }
-
             bool status = ImGui.Begin("Actor Parameters");
 
-            string actorName = ((BymlNode<string>)mSelectedActor["Gyaml"]).Data;
-
-            ImGui.Text(actorName);
-
-            if (ImGui.BeginChild("Placement"))
+            if (mSelectedActor is null)
             {
-                PlacementNode(mSelectedActor);
-            }
-
-            /* actor parameters are loaded from the dynamic node */
-            if (mSelectedActor.ContainsKey("Dynamic"))
-            {
-                DynamicParamNode(mSelectedActor, actorName);
+                ImGui.Text("No Actor is selected");
             }
             else
             {
-                ImGui.TreePop();
+                string actorName = ((BymlNode<string>)mSelectedActor["Gyaml"]).Data;
+
+                ImGui.Text(actorName);
+
+                if (ImGui.BeginChild("Placement"))
+                {
+                    PlacementNode(mSelectedActor);
+                }
+
+                /* actor parameters are loaded from the dynamic node */
+                if (mSelectedActor.ContainsKey("Dynamic"))
+                {
+                    DynamicParamNode(mSelectedActor, actorName);
+                }
+                else
+                {
+                    ImGui.TreePop();
+                }
             }
+            
 
             if (status)
             {

--- a/Fushigi/util/UserSettings.cs
+++ b/Fushigi/util/UserSettings.cs
@@ -32,6 +32,8 @@ namespace Fushigi.util
             else
             {
                 AppSettings = JsonConvert.DeserializeObject<Settings>(File.ReadAllText(SettingsPath));
+
+                RomFS.SetRoot(AppSettings.RomFSPath);
             }
         }
 


### PR DESCRIPTION
- Course selection now opens up right away if the user has a romfs path set
- Added welcome message for those who do not have romfs path set
- Course selection goes away when course is selected
- Course selection can be opened with new File->Open Course button in main menu
- Actors get unselected when changing course areas
- Actor parameters is now always displayed, which is good for layout purposes

New open course button
![image](https://github.com/shibbo/Fushigi/assets/92652573/e5b324ba-546a-404a-bbc4-502ab81b219f)

Look at layout without course select, as well as the actor parameters displayed without a selected actor
![image](https://github.com/shibbo/Fushigi/assets/92652573/feee68da-899a-41cb-ba46-1635c795a4c7)

Simple welcome message
![image](https://github.com/shibbo/Fushigi/assets/92652573/a08ca856-6e4b-41d3-afda-080b0b4969bd)