### PR TITLE
Load latest selected course on startup

### DIFF
--- a/Fushigi/course/Course.cs
+++ b/Fushigi/course/Course.cs
@@ -65,7 +65,7 @@ namespace Fushigi.course
             return mAreas.ElementAt(idx);
         }
 
-        public CourseArea GetArea(string name)
+        public CourseArea? GetArea(string name)
         {
             foreach (CourseArea area in mAreas)
             {

--- a/Fushigi/ui/MainWindow.cs
+++ b/Fushigi/ui/MainWindow.cs
@@ -37,7 +37,7 @@ namespace Fushigi.ui
         void LoadFromSettings()
         {
             string romFSPath = UserSettings.GetRomFSPath();
-            if (romFSPath != null)
+            if (!string.IsNullOrEmpty(romFSPath))
             {
                 RomFS.SetRoot(romFSPath);
             }

--- a/Fushigi/ui/MainWindow.cs
+++ b/Fushigi/ui/MainWindow.cs
@@ -46,7 +46,7 @@ namespace Fushigi.ui
             if (latestCourse != null)
             {
                 mCurrentCourseName = latestCourse;
-                mSelectedCourseScene = new(new(mCurrentCourseName), mWindow);
+                mSelectedCourseScene = new(new(mCurrentCourseName));
                 mIsChoosingCourse = false;
             }
         }
@@ -150,7 +150,7 @@ namespace Fushigi.ui
                             // Only change the course if it is different from current
                             if (mCurrentCourseName == null || mCurrentCourseName != courseLocation)
                             {
-                                mSelectedCourseScene = new(new(courseLocation), mWindow);
+                                mSelectedCourseScene = new(new(courseLocation));
                                 UserSettings.AppendRecentCourse(courseLocation);
                             }
 

--- a/Fushigi/ui/MainWindow.cs
+++ b/Fushigi/ui/MainWindow.cs
@@ -22,6 +22,7 @@ namespace Fushigi.ui
         public MainWindow()
         {
             WindowManager.CreateWindow(out mWindow);
+            LoadFromSettings();
             mWindow.Load += () => WindowManager.RegisterRenderDelegate(mWindow, Render);
             mWindow.Closing += Close;
             mWindow.Run();
@@ -31,6 +32,23 @@ namespace Fushigi.ui
         public void Close()
         {
             UserSettings.Save();
+        }
+
+        void LoadFromSettings()
+        {
+            string romFSPath = UserSettings.GetRomFSPath();
+            if (romFSPath != null)
+            {
+                RomFS.SetRoot(romFSPath);
+            }
+
+            string? latestCourse = UserSettings.GetLatestCourse();
+            if (latestCourse != null)
+            {
+                mCurrentCourseName = latestCourse;
+                mSelectedCourseScene = new(new(mCurrentCourseName), mWindow);
+                mIsChoosingCourse = false;
+            }
         }
 
         void DrawMainMenu()
@@ -132,7 +150,8 @@ namespace Fushigi.ui
                             // Only change the course if it is different from current
                             if (mCurrentCourseName == null || mCurrentCourseName != courseLocation)
                             {
-                                mSelectedCourseScene = new(new(courseLocation), mWindow);        
+                                mSelectedCourseScene = new(new(courseLocation), mWindow);
+                                UserSettings.AppendRecentCourse(courseLocation);
                             }
 
                         }

--- a/Fushigi/ui/widgets/CourseScene.cs
+++ b/Fushigi/ui/widgets/CourseScene.cs
@@ -98,14 +98,16 @@ namespace Fushigi.ui.widgets
             {
                 if (ImGui.BeginTabItem(area.GetName()))
                 {
-                    // Unselect actor on tab change
-                    // This is so that users do not see an actor selected from another area
+                    // Tab change
                     if (selectedArea != area)
                     {
+                        selectedArea = area;
+                        viewport = new(area);
+
+                        // Unselect actor
+                        // This is so that users do not see an actor selected from another area
                         mSelectedActor = null;
                     }
-
-                    selectedArea = area;
 
                     ImGui.EndTabItem();
                 }

--- a/Fushigi/ui/widgets/CourseScene.cs
+++ b/Fushigi/ui/widgets/CourseScene.cs
@@ -19,34 +19,17 @@ namespace Fushigi.ui.widgets
         readonly Course course;
         CourseArea selectedArea;
 
-        private const int gridBasePixelsPerUnit = 32;
-
-        ImDrawListPtr drawList;
-
-        Vector2 areaScenePan = new();
-        float areaSceneZoom = 1;
-        float gridPixelsPerUnit;
-
-        //canvas viewport coordinates
-        Vector2 canvasMin;
-        Vector2 canvasSize;
-        Vector2 canvasMax;
-        Vector2 canvasMidpoint;
-
-        Vector2 panOrigin;
         readonly Dictionary<string, bool> mLayersVisibility = [];
         bool mHasFilledLayers = false;
-        readonly IWindow mParentWindow;
         bool mAllLayersVisible = true;
 
         BymlHashTable? mSelectedActor = null;
 
-        public CourseScene(Course course, IWindow window)
+        public CourseScene(Course course)
         {
             this.course = course;
             selectedArea = course.GetArea(0);
             viewport = new LevelViewport(selectedArea);
-            mParentWindow = window;
         }
 
         public void DrawUI()

--- a/Fushigi/util/UserSettings.cs
+++ b/Fushigi/util/UserSettings.cs
@@ -11,7 +11,9 @@ namespace Fushigi.util
 {
     public static class UserSettings
     {
-        public static readonly string SettingsPath = "UserSettings.json";
+        public static readonly string SettingsDir = 
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        public static readonly string SettingsFile = Path.Combine(SettingsDir, "UserSettings.json");
         public static readonly int MaxRecents = 10;
         static Settings AppSettings;
 
@@ -25,7 +27,7 @@ namespace Fushigi.util
 
         public static void Load()
         {
-            if (!File.Exists(SettingsPath))
+            if (!File.Exists(SettingsFile))
             {
                 AppSettings.RomFSPath = "";
                 AppSettings.ModPaths = new();
@@ -34,13 +36,18 @@ namespace Fushigi.util
             }
             else
             {
-                AppSettings = JsonConvert.DeserializeObject<Settings>(File.ReadAllText(SettingsPath));
+                AppSettings = JsonConvert.DeserializeObject<Settings>(File.ReadAllText(SettingsFile));
             }
         }
 
         public static void Save()
         {
-            File.WriteAllText(SettingsPath, JsonConvert.SerializeObject(AppSettings, Formatting.Indented));
+            if (!Directory.Exists(SettingsDir))
+            {
+                Directory.CreateDirectory(SettingsDir);
+            }
+
+            File.WriteAllText(SettingsFile, JsonConvert.SerializeObject(AppSettings, Formatting.Indented));
         }
 
         public static void SetRomFSPath(string path)

--- a/Fushigi/util/UserSettings.cs
+++ b/Fushigi/util/UserSettings.cs
@@ -32,8 +32,6 @@ namespace Fushigi.util
             else
             {
                 AppSettings = JsonConvert.DeserializeObject<Settings>(File.ReadAllText(SettingsPath));
-
-                RomFS.SetRoot(AppSettings.RomFSPath);
             }
         }
 
@@ -57,7 +55,7 @@ namespace Fushigi.util
             AppSettings.ModPaths.Add(modname, path);
         }
 
-        public static void AppendRecentFile(string path)
+        public static void AppendRecentCourse(string courseName)
         {
             // please let me know if this isn't a good implementation
             if (AppSettings.RecentCourses.Count == MaxRecents)
@@ -70,12 +68,24 @@ namespace Fushigi.util
 
                 AppSettings.RecentCourses = [.. newArray];
                 // put our brand new path at 9
-                AppSettings.RecentCourses[MaxRecents - 1] = path;
+                AppSettings.RecentCourses[MaxRecents - 1] = courseName;
             }
             else
             {
-                AppSettings.RecentCourses.Add(path);
+                AppSettings.RecentCourses.Add(courseName);
             }
+        }
+
+        public static string? GetLatestCourse()
+        {
+            int size = AppSettings.RecentCourses.Count;
+            
+            if (size == 0)
+            {
+                return null;
+            }
+
+            return AppSettings.RecentCourses[size - 1];
         }
     }
 }


### PR DESCRIPTION
- Implement and leverage UserSettings.RecentCourses to load the latest selected course on application startup
  - This means UserSettings.RecentCourses is now being kept track of, so feel free to use it for anything else you may need
- Fix bug where viewport was not updating on tab switch
- Cleaned up CourseScene.cs unused fields after the LevelViewport transition