### PR TITLE
Extension checking in ParamDB Load

### DIFF
--- a/Fushigi/param/ParamDB.cs
+++ b/Fushigi/param/ParamDB.cs
@@ -75,17 +75,20 @@ namespace Fushigi.param
             /* iterate through each file */
             foreach (string file in files)
             {
-                /* make sure the file is a zstd file before we continue */
-                if (!file.EndsWith(".zs")) {
-                    continue;
-                }
                 /* the actor name in question is at the beginning of the file name */
                 string actorName = Path.GetFileNameWithoutExtension(file).Split(".pack")[0];
                 ActorParam param = new ActorParam();
                 param.Components = new List<string>();
 
-                /* each .pack file is ZSTD compressed */
-                byte[] fileBytes = FileUtil.DecompressFile(file);
+                /* each .pack file should be ZSTD compressed, if not, skip the file */
+                byte[] fileBytes;
+                try {
+                    fileBytes = FileUtil.DecompressFile(file);
+                }
+                catch (Exception) {
+                    continue;
+                }
+
                 SARC.SARC sarc = new SARC.SARC(new MemoryStream(fileBytes));
 
                 /* /Component/Blackboard/BlackboardParamTable is where all of the actor-specific parameters live */

--- a/Fushigi/param/ParamDB.cs
+++ b/Fushigi/param/ParamDB.cs
@@ -75,6 +75,10 @@ namespace Fushigi.param
             /* iterate through each file */
             foreach (string file in files)
             {
+                /* make sure the file is a zstd file before we continue */
+                if (!file.EndsWith(".zs")) {
+                    continue;
+                }
                 /* the actor name in question is at the beginning of the file name */
                 string actorName = Path.GetFileNameWithoutExtension(file).Split(".pack")[0];
                 ActorParam param = new ActorParam();

--- a/Fushigi/util/FileUtil.cs
+++ b/Fushigi/util/FileUtil.cs
@@ -37,7 +37,12 @@ namespace Fushigi.util
 
         public static bool IsFileCompressed(byte[] fileBytes)
         {
-            if (fileBytes[0] == 0x28 && fileBytes[1] == 0xb5) {
+            /* Zstandard frame metadata */
+            if (fileBytes[0] == 0x28 && fileBytes[1] == 0xb5 && fileBytes[2] == 0x2f && fileBytes[3] == 0xfd) {
+                return true;
+            }
+            /* Skippable frame metadata, skips the first byte because it can be variable */
+            else if (fileBytes[1] == 0x2a && fileBytes[1] == 0x4d && fileBytes[2] == 0x18) {
                 return true;
             }
             else {

--- a/Fushigi/util/FileUtil.cs
+++ b/Fushigi/util/FileUtil.cs
@@ -16,13 +16,7 @@ namespace Fushigi.util
             }
 
             var compressedBytes = File.ReadAllBytes(filePath);
-            byte[] decompressedData;
-
-            using (var decompressor = new ZstdNet.Decompressor())
-            {
-                decompressedData = decompressor.Unwrap(compressedBytes);
-            }
-
+            byte[] decompressedData = DecompressData(compressedBytes);
             return decompressedData;
         }
 
@@ -30,12 +24,25 @@ namespace Fushigi.util
         {
             byte[] decompressedData;
 
+            if (!IsFileCompressed(fileBytes)) {
+                throw new Exception("FileUtil::DecompressData -- File not ZSTD Compressed.");
+            }
             using (var decompressor = new ZstdNet.Decompressor())
             {
                 decompressedData = decompressor.Unwrap(fileBytes);
             }
 
             return decompressedData;
+        }
+
+        public static bool IsFileCompressed(byte[] fileBytes)
+        {
+            if (fileBytes[0] == 0x28 && fileBytes[1] == 0xb5) {
+                return true;
+            }
+            else {
+                return false;
+            }
         }
 
         public static byte[] CompressData(byte[] fileBytes)


### PR DESCRIPTION
This pull request adds a quick check to the ParamDB.Load() method to make sure the file being loaded has the .zs extension.

This was a personal issue, but I thought it'd be good to make a PR to fix it incase anyone else runs into the same issue I did.