### PR TITLE
Mod path

### DIFF
--- a/Fushigi/course/Course.cs
+++ b/Fushigi/course/Course.cs
@@ -29,11 +29,11 @@ namespace Fushigi.course
 
         public void LoadFromRomFS()
         {
-            byte[] courseBytes = RomFS.GetFileBytes($"BancMapUnit/{mCourseName}.bcett.byml.zs");
-            byte[] stageParamBytes = RomFS.GetFileBytes($"Stage/StageParam/{mCourseName}.game__stage__StageParam.bgyml");
+            var courseFilePath = FileUtil.FindContentPath($"BancMapUnit/{mCourseName}.bcett.byml.zs");
+            var stageParamFilePath = FileUtil.FindContentPath($"Stage/StageParam/{mCourseName}.game__stage__StageParam.bgyml");
             /* grab our course information file */
-            Byml.Byml courseInfo = new Byml.Byml(new MemoryStream(FileUtil.DecompressData(courseBytes)));
-            Byml.Byml stageParam = new Byml.Byml(new MemoryStream(stageParamBytes));
+            Byml.Byml courseInfo = new Byml.Byml(new MemoryStream(FileUtil.DecompressFile(courseFilePath)));
+            Byml.Byml stageParam = new Byml.Byml(new MemoryStream(File.ReadAllBytes(stageParamFilePath)));
 
             var stageParamRoot = (BymlHashTable)stageParam.Root;
 

--- a/Fushigi/course/CourseArea.cs
+++ b/Fushigi/course/CourseArea.cs
@@ -31,11 +31,15 @@ namespace Fushigi.course
 
         public void Save()
         {
-            Save($"{RomFS.GetRoot()}/BancMapUnit");
+            //Save using the configured mod romfs path
+            Save($"{UserSettings.GetModRomFSPath()}/BancMapUnit");
         }
 
         public void Save(string folder)
         {
+            if (!Directory.Exists(folder))
+                Directory.CreateDirectory(folder);
+
             var byml = new Byml.Byml(this.GetRootNode());
             //Save byml into memory to be compressed
             var mem = new MemoryStream();

--- a/Fushigi/course/CourseArea.cs
+++ b/Fushigi/course/CourseArea.cs
@@ -21,10 +21,10 @@ namespace Fushigi.course
 
         public void Load()
         {
-            string areaParamPath = $"{RomFS.GetRoot()}/Stage/AreaParam/{mAreaName}.game__stage__AreaParam.bgyml";
+            string areaParamPath = FileUtil.FindContentPath($"Stage/AreaParam/{mAreaName}.game__stage__AreaParam.bgyml");
             mAreaParams = new AreaParam(new Byml.Byml(new MemoryStream(File.ReadAllBytes(areaParamPath))));
 
-            string levelPath = $"{RomFS.GetRoot()}/BancMapUnit/{mAreaName}.bcett.byml.zs";
+            string levelPath = FileUtil.FindContentPath($"BancMapUnit/{mAreaName}.bcett.byml.zs");
             byte[] levelBytes = FileUtil.DecompressFile(levelPath);
             mLevelByml = new Byml.Byml(new MemoryStream(levelBytes));
         }

--- a/Fushigi/ui/MainWindow.cs
+++ b/Fushigi/ui/MainWindow.cs
@@ -83,13 +83,27 @@ namespace Fushigi.ui
 
                     if (ImGui.MenuItem("Save") && mSelectedCourseScene != null)
                     {
-                        mSelectedCourseScene.Save();
+                        //Ensure the romfs path is set for saving
+                        if (!string.IsNullOrEmpty(UserSettings.GetModRomFSPath()))
+                            mSelectedCourseScene.Save();
+                        else //Else configure the mod path
+                        {
+                            FolderDialog dlg = new FolderDialog();
+                            if (dlg.ShowDialog("Select the romfs directory to save to."))
+                            {
+                                UserSettings.SetModRomFSPath(dlg.SelectedPath);
+                                mSelectedCourseScene.Save();
+                            }
+                        }
                     }
                     if (ImGui.MenuItem("Save As") && mSelectedCourseScene != null)
                     {
                         FolderDialog dlg = new FolderDialog();
-                        if (dlg.ShowDialog())
-                            mSelectedCourseScene.Save(dlg.SelectedPath);
+                        if (dlg.ShowDialog("Select the romfs directory to save to."))
+                        {
+                            UserSettings.SetModRomFSPath(dlg.SelectedPath);
+                            mSelectedCourseScene.Save();
+                        }
                     }
 
                     ImGui.PopStyleColor();

--- a/Fushigi/util/FileUtil.cs
+++ b/Fushigi/util/FileUtil.cs
@@ -8,6 +8,15 @@ namespace Fushigi.util
 {
     public class FileUtil
     {
+        public static string FindContentPath(string path)
+        {
+            //Check for mod folder, then fall to romfs path
+            if (File.Exists($"{UserSettings.GetModRomFSPath()}/{path}"))
+                return $"{UserSettings.GetModRomFSPath()}/{path}";
+
+            return $"{UserSettings.GetRomFSPath()}/{path}";
+        }
+
         public static byte[] DecompressFile(string filePath)
         {
             if (!File.Exists(filePath))

--- a/Fushigi/util/UserSettings.cs
+++ b/Fushigi/util/UserSettings.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -17,6 +18,7 @@ namespace Fushigi.util
         struct Settings
         {
             public string RomFSPath;
+            public string RomFSModPath;
             public Dictionary<string, string> ModPaths;
             public List<string> RecentCourses;
         }
@@ -27,6 +29,7 @@ namespace Fushigi.util
             {
                 AppSettings.RomFSPath = "";
                 AppSettings.ModPaths = new();
+                AppSettings.RomFSModPath = "";
                 AppSettings.RecentCourses = new List<string>(MaxRecents);
             }
             else
@@ -45,11 +48,23 @@ namespace Fushigi.util
         public static void SetRomFSPath(string path)
         {
             AppSettings.RomFSPath = path;
+            Save(); //save setting
+        }
+
+        public static void SetModRomFSPath(string path)
+        {
+            AppSettings.RomFSModPath = path;
+            Save(); //save setting
         }
 
         public static string GetRomFSPath()
         {
             return AppSettings.RomFSPath;
+        }
+
+        public static string GetModRomFSPath()
+        {
+            return AppSettings.RomFSModPath;
         }
 
         public static void AppendModPath(string modname, string path)


### PR DESCRIPTION
When a user saves a course, it will prompt the user to select a "romfs mod path" which will save modded files there. This can also be reconfigured using the "Save As" menu. 

Modded files will also be loaded back depending if the file is present in the path or not. 

FileUtil.FindContentPath() gets the file from either the mod folder (if present) or the romfs by default. 

I also modifed the Set() functions in the settings to save the config, since that was not applying for me even after close. 