### PR TITLE
Add startup menu for selecting the romfs and mod folders.

### DIFF
--- a/Fushigi/ui/MainWindow.cs
+++ b/Fushigi/ui/MainWindow.cs
@@ -165,7 +165,16 @@ namespace Fushigi.ui
         {
             if (ImGui.Begin("Welcome"))
             {
-                ImGui.Text("Welcome to Fushigi! Visit 'File->Set RomFS Path' to get started.");
+                ImGui.Text("Welcome to Fushigi! Set the RomFS game path and mod path to save to get started.");
+
+                var romfs = UserSettings.GetRomFSPath();
+                var mod = UserSettings.GetModRomFSPath();
+
+                if (PathSelector.Show("RomFS Game Path", ref romfs, !string.IsNullOrEmpty(romfs)))
+                    UserSettings.SetRomFSPath(romfs);
+
+                if (PathSelector.Show("RomFS Mod Path", ref mod, !string.IsNullOrEmpty(mod)))
+                    UserSettings.SetModRomFSPath(mod);
 
                 ImGui.End();
             }
@@ -188,7 +197,8 @@ namespace Fushigi.ui
             DrawMainMenu();
 
             /* if our RomFS is selected, fill the course list */
-            if (RomFS.GetRoot() != null)
+            if (!string.IsNullOrEmpty(RomFS.GetRoot()) && 
+                !string.IsNullOrEmpty(UserSettings.GetModRomFSPath()))
             {
                 if (mIsChoosingCourse)
                 {

--- a/Fushigi/ui/MainWindow.cs
+++ b/Fushigi/ui/MainWindow.cs
@@ -175,6 +175,7 @@ namespace Fushigi.ui
                 if (PathSelector.Show("RomFS Game Path", ref romfs, Directory.Exists($"{romfs}/BancMapUnit")))
                 {
                     UserSettings.SetRomFSPath(romfs);
+                    RomFS.SetRoot(romfs);
                     /* if our parameter database isn't set, set it */
                     if (!ParamDB.sIsInit)
                     {

--- a/Fushigi/ui/MainWindow.cs
+++ b/Fushigi/ui/MainWindow.cs
@@ -165,7 +165,7 @@ namespace Fushigi.ui
         {
             if (ImGui.Begin("Welcome"))
             {
-                ImGui.Text("Welcome to Fushigi! Set the RomFS game path and mod path to save to get started.");
+                ImGui.Text("Welcome to Fushigi! Set the RomFS game path and save directory to get started.");
 
                 var romfs = UserSettings.GetRomFSPath();
                 var mod = UserSettings.GetModRomFSPath();
@@ -173,7 +173,7 @@ namespace Fushigi.ui
                 if (PathSelector.Show("RomFS Game Path", ref romfs, !string.IsNullOrEmpty(romfs)))
                     UserSettings.SetRomFSPath(romfs);
 
-                if (PathSelector.Show("RomFS Mod Path", ref mod, !string.IsNullOrEmpty(mod)))
+                if (PathSelector.Show("Save Directory", ref mod, !string.IsNullOrEmpty(mod)))
                     UserSettings.SetModRomFSPath(mod);
 
                 ImGui.End();

--- a/Fushigi/ui/MainWindow.cs
+++ b/Fushigi/ui/MainWindow.cs
@@ -170,6 +170,8 @@ namespace Fushigi.ui
                 var romfs = UserSettings.GetRomFSPath();
                 var mod = UserSettings.GetModRomFSPath();
 
+                ImGui.Indent();
+
                 if (PathSelector.Show("RomFS Game Path", ref romfs, Directory.Exists($"{romfs}/BancMapUnit")))
                 {
                     UserSettings.SetRomFSPath(romfs);

--- a/Fushigi/ui/MainWindow.cs
+++ b/Fushigi/ui/MainWindow.cs
@@ -170,11 +170,22 @@ namespace Fushigi.ui
                 var romfs = UserSettings.GetRomFSPath();
                 var mod = UserSettings.GetModRomFSPath();
 
-                if (PathSelector.Show("RomFS Game Path", ref romfs, !string.IsNullOrEmpty(romfs)))
+                if (PathSelector.Show("RomFS Game Path", ref romfs, Directory.Exists($"{romfs}/BancMapUnit")))
+                {
                     UserSettings.SetRomFSPath(romfs);
+                    /* if our parameter database isn't set, set it */
+                    if (!ParamDB.sIsInit)
+                    {
+                        ParamDB.Load();
+                    }
+                }
+
+                Tooltip.Show("The game files which are stored under the romfs folder.");
 
                 if (PathSelector.Show("Save Directory", ref mod, !string.IsNullOrEmpty(mod)))
                     UserSettings.SetModRomFSPath(mod);
+
+                Tooltip.Show("The save output where to save modified romfs files");
 
                 ImGui.End();
             }

--- a/Fushigi/ui/widgets/PathSelector.cs
+++ b/Fushigi/ui/widgets/PathSelector.cs
@@ -1,0 +1,65 @@
+﻿using ImGuiNET;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fushigi.ui.widgets
+{
+    /// <summary>
+    /// A widget for displaying a given directory path with a button to select one. 
+    /// </summary>
+    internal class PathSelector
+    {
+        public static bool Show(string label, ref string path, bool isValid = true)
+        {
+            //Ensure path isn't null for imgui
+            if (path == null)
+                path = "";
+
+            //Validiate directory
+            if (!System.IO.Directory.Exists(path))
+                isValid = false;
+
+            bool clicked = ImGui.Button($"  -  ##{label}");
+            bool edited = false;
+
+            ImGui.SameLine();
+            if (!isValid)
+            {
+                ImGui.PushStyleColor(ImGuiCol.FrameBg, new Vector4(0.5f, 0, 0, 1));
+                ImGui.InputText(label, ref path, 500, ImGuiInputTextFlags.ReadOnly);
+                ImGui.PopStyleColor();
+            }
+            else
+            {
+                ImGui.PushStyleColor(ImGuiCol.FrameBg, new Vector4(0, 0.5f, 0, 1));
+                ImGui.InputText(label, ref path, 500, ImGuiInputTextFlags.ReadOnly);
+                ImGui.PopStyleColor();
+            }
+
+            if (ImGui.BeginPopupContextItem($"{label}_clear", ImGuiPopupFlags.MouseButtonRight))
+            {
+                if (ImGui.MenuItem("Clear"))
+                {
+                    path = "";
+                    edited = true;
+                }
+                ImGui.EndPopup();
+            }
+
+            if (clicked)
+            {
+                var dialog = new FolderDialog();
+                if (dialog.ShowDialog())
+                {
+                    path = dialog.SelectedPath;
+                    return true;
+                }
+            }
+            return edited;
+        }
+    }
+}

--- a/Fushigi/ui/widgets/PathSelector.cs
+++ b/Fushigi/ui/widgets/PathSelector.cs
@@ -25,18 +25,24 @@ namespace Fushigi.ui.widgets
 
             bool clicked = ImGui.Button($"  -  ##{label}");
             bool edited = false;
-
             ImGui.SameLine();
+
+            ImGui.Columns(2);
+
+            ImGui.Text(label);
+
+            ImGui.NextColumn();
+
             if (!isValid)
             {
                 ImGui.PushStyleColor(ImGuiCol.FrameBg, new Vector4(0.5f, 0, 0, 1));
-                ImGui.InputText(label, ref path, 500, ImGuiInputTextFlags.ReadOnly);
+                ImGui.InputText($"##{label}", ref path, 500, ImGuiInputTextFlags.ReadOnly);
                 ImGui.PopStyleColor();
             }
             else
             {
                 ImGui.PushStyleColor(ImGuiCol.FrameBg, new Vector4(0, 0.5f, 0, 1));
-                ImGui.InputText(label, ref path, 500, ImGuiInputTextFlags.ReadOnly);
+                ImGui.InputText($"##{label}", ref path, 500, ImGuiInputTextFlags.ReadOnly);
                 ImGui.PopStyleColor();
             }
 
@@ -49,6 +55,10 @@ namespace Fushigi.ui.widgets
                 }
                 ImGui.EndPopup();
             }
+
+            ImGui.NextColumn();
+
+            ImGui.Columns(1);
 
             if (clicked)
             {

--- a/Fushigi/ui/widgets/PathSelector.cs
+++ b/Fushigi/ui/widgets/PathSelector.cs
@@ -23,15 +23,17 @@ namespace Fushigi.ui.widgets
             if (!System.IO.Directory.Exists(path))
                 isValid = false;
 
-            bool clicked = ImGui.Button($"  -  ##{label}");
-            bool edited = false;
-            ImGui.SameLine();
-
             ImGui.Columns(2);
+
+            ImGui.SetColumnWidth(0, 150);
+
+            bool edited = false;
 
             ImGui.Text(label);
 
             ImGui.NextColumn();
+
+            ImGui.PushItemWidth(ImGui.GetColumnWidth() - 100);
 
             if (!isValid)
             {
@@ -55,6 +57,11 @@ namespace Fushigi.ui.widgets
                 }
                 ImGui.EndPopup();
             }
+
+            ImGui.PopItemWidth();
+
+            ImGui.SameLine();
+            bool clicked = ImGui.Button($"Select##{label}");
 
             ImGui.NextColumn();
 

--- a/Fushigi/ui/widgets/Tooltip.cs
+++ b/Fushigi/ui/widgets/Tooltip.cs
@@ -1,0 +1,21 @@
+﻿using ImGuiNET;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fushigi.ui.widgets
+{
+    /// <summary>
+    /// Displays a tooltip from the previously drawn item.
+    /// </summary>
+    internal class Tooltip
+    {
+        public static void Show(string text)
+        {
+            if (ImGui.IsItemHovered()) //TODO add delay
+                ImGui.SetTooltip(text);
+        }
+    }
+}


### PR DESCRIPTION
![image](https://github.com/shibbo/Fushigi/assets/13475262/e561f5d0-0a71-4398-983c-c28eadfbd0dd)

When the user first loads the tool, it will prompt to select both the game romfs and a save  folder where edits are saved to. 

This also includes a PathSelector widget which can be reused for the settings window whenever that is made. 