### PR TITLE
Add support for RSTB updating.

### DIFF
--- a/Fushigi/course/CourseArea.cs
+++ b/Fushigi/course/CourseArea.cs
@@ -1,4 +1,5 @@
 ﻿using Fushigi.Byml;
+using Fushigi.rstb;
 using Fushigi.util;
 using ImGuiNET;
 using System;
@@ -29,13 +30,13 @@ namespace Fushigi.course
             mLevelByml = new Byml.Byml(new MemoryStream(levelBytes));
         }
 
-        public void Save()
+        public void Save(RSTB resource_table)
         {
             //Save using the configured mod romfs path
-            Save($"{UserSettings.GetModRomFSPath()}/BancMapUnit");
+            Save(resource_table, $"{UserSettings.GetModRomFSPath()}/BancMapUnit");
         }
 
-        public void Save(string folder)
+        public void Save(RSTB resource_table, string folder)
         {
             if (!Directory.Exists(folder))
                 Directory.CreateDirectory(folder);
@@ -45,9 +46,14 @@ namespace Fushigi.course
             var mem = new MemoryStream();
             byml.Save(mem);
 
+            var decomp_size = (uint)mem.Length;
+
             //Compress and save the course area
             string levelPath = $"{folder}/{mAreaName}.bcett.byml.zs";
             File.WriteAllBytes(levelPath, FileUtil.CompressData(mem.ToArray()));
+
+            //Update resource table
+            resource_table.SetResource($"BancMapUnit/{mAreaName}.bcett.byml", decomp_size);
         }
 
         public string GetName()

--- a/Fushigi/rstb/RSTB.cs
+++ b/Fushigi/rstb/RSTB.cs
@@ -1,0 +1,205 @@
+﻿using Fushigi.util;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fushigi.rstb
+{
+    public class RSTB
+    {
+        [StructLayout(LayoutKind.Sequential, Size = 0x10)]
+        struct Header
+        {
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 6)]
+            public byte[] Magic; //RESTBL
+
+            public uint Version; //1
+            public uint StringBlockSize; //160 for wonder
+            public uint CrcTableNum;
+            public uint NameTableNum;
+        }
+
+        /// <summary>
+        /// A lookup of file hashes and their resource sizes used.
+        /// </summary>
+        public Dictionary<uint, uint> HashToResourceSize = new Dictionary<uint, uint>();
+
+        /// <summary>
+        /// A lookup of file names and their resource sizes used.
+        /// This is only used when hashes conflict and cannot be used for the hash table.
+        /// </summary>
+        public Dictionary<string, uint> StringToResourceSize = new Dictionary<string, uint>();
+
+        /// <summary>
+        /// The RSTB file header.
+        /// </summary>
+        private Header FileHeader;
+
+        /// <summary>
+        /// Sets a resource given a file path and decompressed size.
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <param name="decompressed_size"></param>
+        public void SetResource(string filePath, uint decompressed_size)
+        {
+            //Get file name without .zs extension
+            string path = filePath.Replace(".zs", "");
+            string ext = Path.GetExtension(filePath);
+            //Compute hash to find in the resource table
+            uint hash = Crc32.Compute(path);
+            //Update the resource size
+            if (HashToResourceSize.ContainsKey(hash))
+                HashToResourceSize[hash] = CalculateResourceSize(decompressed_size, ext);
+            else
+            {
+                Console.WriteLine($"Warning! File {path} not found in resource table!");
+            }
+        }
+
+        /// <summary>
+        /// Loads the resource table from the romfs or saved content path configured in the tool settings.
+        /// </summary>
+        public void Load()
+        {
+            string path = FileUtil.FindContentPath("System/Resource/ResourceSizeTable.Product.100.rsizetable.zs");
+            //Failed to find file, skip
+            if (!File.Exists(path))
+                return;
+
+            Read(new MemoryStream(FileUtil.DecompressFile(path)));
+        }
+
+        /// <summary>
+        /// Save the resource table to the saved romfs path configured in the tool settings.
+        /// </summary>
+        public void Save()
+        {
+            if (HashToResourceSize.Count == 0) //File not loaded, return
+                return;
+
+            string dir = $"{UserSettings.GetModRomFSPath()}/System/Resource";
+            if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+
+            var mem = new MemoryStream();
+            Write(mem);
+            File.WriteAllBytes($"{dir}/ResourceSizeTable.Product.100.rsizetable.zs", FileUtil.CompressData(mem.ToArray()));
+        }
+
+        private void Read(Stream stream)
+        {
+            using (var reader = new BinaryReader(stream))
+            {
+                FileHeader = new Header()
+                {
+                    Magic = reader.ReadBytes(6), //RESTBL
+                    Version = reader.ReadUInt32(),
+                    StringBlockSize = reader.ReadUInt32(),
+                    CrcTableNum = reader.ReadUInt32(),
+                    NameTableNum = reader.ReadUInt32(),
+                };
+                for (int i = 0; i < FileHeader.CrcTableNum; i++)
+                {
+                    uint hash = reader.ReadUInt32();
+                    uint size = reader.ReadUInt32();
+                    HashToResourceSize.Add(hash, size);
+                }
+                for (int i = 0; i < FileHeader.NameTableNum; i++)
+                {
+                    //Fixed 128 byte string in UTF8 format
+                    string name = Encoding.UTF8.GetString(reader.ReadBytes(128)).Replace("\0", string.Empty);
+                    uint size = reader.ReadUInt32();
+                    StringToResourceSize.Add(name, size);
+                }
+            }
+        }
+
+        private void Write(Stream stream)
+        {
+            FileHeader.CrcTableNum = (uint)this.HashToResourceSize.Count;
+
+            using (var writer = new BinaryWriter(stream))
+            {
+                writer.Write(FileHeader.Magic);
+                writer.Write(FileHeader.Version);
+                writer.Write(FileHeader.StringBlockSize);
+                writer.Write(FileHeader.CrcTableNum);
+                writer.Write(FileHeader.NameTableNum);
+
+                //Sort by hash
+                foreach (var pair in HashToResourceSize.OrderBy(x => x.Key))
+                {
+                    writer.Write(pair.Key);
+                    writer.Write(pair.Value);
+                }
+                foreach (var pair in StringToResourceSize.OrderBy(x => x.Key))
+                {
+                    writer.Write(new byte[128]); //reserve string space
+                    //write string
+                    writer.Seek(-128, SeekOrigin.Current);
+                    writer.Write(Encoding.UTF8.GetBytes(pair.Key));
+                    writer.Write(pair.Value);
+                }
+            }
+        }
+
+        private uint CalculateResourceSize(uint decompressed_size, string ext)
+        {
+            //According to BOTW wiki, calculation goes like this 
+            //(size rounded up to multiple of 32) + CONSTANT + sizeof(ResourceClass) + PARSE_SIZE
+
+            //Round to nearest 32
+            var size = (decompressed_size + 31) & -32;
+
+            //Formats which are verified to be the correct size
+            switch (ext)
+            {
+                case ".byml": //For bcett.byml, the total added after rounding is always 0x100 bytes
+                    return (uint)size + 0x100;
+                case ".pack": //Always 0x180 including actor .pack files
+                case ".sarc": //Mal and agl sarc files
+                case ".blarc": //Layout sarc files
+                    return (uint)size + 0x180;
+                case ".genvb": //Tested from Env folder
+                    return (uint)size + 0x2000;
+            }
+
+            //Default
+            return (uint)size + 0x1000;
+        }
+
+        /// <summary>
+        /// A test to verify the padding size of resource buffers from a folder of files.
+        /// </summary>
+        private void TestPrintResourceBuffer(string folder)
+        {
+            foreach (var file in RomFS.GetFiles(folder))
+            {
+                //Decompressed file size
+                var size = 0;
+                if (file.EndsWith(".zs"))
+                    size = (int)FileUtil.DecompressFile(file).Length;
+                else
+                    size = (int)new FileInfo(file).Length;
+
+                //Get resource hash
+                string path = $"{folder}/{Path.GetFileName(file).Replace(".zs", "")}";
+                uint hash = Crc32.Compute(path);
+
+                if (this.HashToResourceSize.ContainsKey(hash))
+                {
+                    //Round to nearest 32
+                    size = (size + 31) & -32;
+
+                    //Find difference in raw file size and resource size
+                    uint resource_size = this.HashToResourceSize[hash];
+                    int diff = (int)resource_size - size;
+                    Console.WriteLine($"decomp_size {size} resource_size difference {diff} path {path}");
+                }
+            }
+        }
+    }
+}

--- a/Fushigi/ui/widgets/CourseScene.cs
+++ b/Fushigi/ui/widgets/CourseScene.cs
@@ -1,6 +1,7 @@
 ﻿using Fushigi.Byml;
 using Fushigi.course;
 using Fushigi.param;
+using Fushigi.rstb;
 using ImGuiNET;
 using Newtonsoft.Json.Linq;
 using Silk.NET.Input;
@@ -69,16 +70,14 @@ namespace Fushigi.ui.widgets
 
         public void Save()
         {
+            RSTB resource_table = new RSTB();
+            resource_table.Load();
+
             //Save each course area to current romfs folder
             foreach (var area in this.course.GetAreas())
-                area.Save();
-        }
+                area.Save(resource_table);
 
-        public void Save(string folder)
-        {
-            //Save each course area to a specific folder
-            foreach (var area in this.course.GetAreas())
-                area.Save(folder);
+            resource_table.Save();
         }
 
         private void CourseTabBar()
@@ -279,7 +278,7 @@ namespace Fushigi.ui.widgets
                     mLayersVisibility[layer] = isVisible;
                 }
 
-                ImGui.SameLine();
+                    ImGui.SameLine();
 
                 if (!isVisible)
                 {

--- a/Fushigi/util/Crc32.cs
+++ b/Fushigi/util/Crc32.cs
@@ -1,0 +1,82 @@
+﻿using System.Text;
+
+namespace Fushigi.util
+{
+    /// <summary>
+    /// Computes a CRC32 checksum.
+    /// </summary>
+    /// <remarks>Based on <see cref="http://sanity-free.org/12/crc32_implementation_in_csharp.html"/></remarks>
+    public static class Crc32
+    {
+        readonly static uint[] Table = CreateTable();
+
+        static Crc32()
+        { }
+
+        /// <summary>
+        /// Compute the checksum of a UTF8 text.
+        /// </summary>
+        /// <param name="text">Text to calculate</param>
+        /// <returns>Checksum</returns>
+        public static uint Compute(string text)
+        {
+            return Compute(text, Encoding.UTF8);
+        }
+
+        /// <summary>
+        /// Compute the checksum of a text using a specific encoding.
+        /// </summary>
+        /// <param name="text">Text to calculate</param>
+        /// <param name="encoding">Text encoding</param>
+        /// <returns>Checksum</returns>
+        public static uint Compute(string text, Encoding encoding)
+        {
+            if (string.IsNullOrEmpty(text)) return 0;
+            byte[] bytes = encoding.GetBytes(text);
+            return Compute(bytes);
+        }
+
+        /// <summary>
+        /// Compute the checksum of a binary buffer.
+        /// </summary>
+        /// <param name="bytes">Buffer to calculate</param>
+        /// <returns></returns>
+        public static uint Compute(byte[] bytes)
+        {
+            uint crc = 0xffffffff;
+            for (int i = 0; i < bytes.Length; ++i)
+            {
+                byte index = (byte)(((crc) & 0xff) ^ bytes[i]);
+                crc = (crc >> 8) ^ Table[index];
+            }
+
+            return unchecked((~crc));
+        }
+
+        static uint[] CreateTable()
+        {
+            const uint poly = 0xedb88320;
+            var table = new uint[256];
+            uint temp = 0;
+            for (uint i = 0; i < table.Length; ++i)
+            {
+                temp = i;
+                for (int j = 8; j > 0; --j)
+                {
+                    if ((temp & 1) == 1)
+                    {
+                        temp = (uint)((temp >> 1) ^ poly);
+                    }
+                    else
+                    {
+                        temp >>= 1;
+                    }
+                }
+
+                table[i] = temp;
+            }
+
+            return table;
+        }
+    }
+}


### PR DESCRIPTION
Adds support for RSTB loading/saving and editing the table. Currently each area .byml is saved with the RSTB values updated. Can confirm this works in game and fixes the level from not loading when the file size gets larger than original size.

The calculation is confirmed to match the original resource size where it is rounded to nearest 32, then adds 0x100 to the size.
A few other extensions with confirmed calculation sizes are added such as .pack for future purposes if we decide to ever edit those files.