### PR TITLE
Support actor framing by camera and view selection in viewport

### DIFF
--- a/Fushigi/ui/widgets/CourseScene.cs
+++ b/Fushigi/ui/widgets/CourseScene.cs
@@ -389,7 +389,13 @@ namespace Fushigi.ui.widgets
                             if (ImGui.Selectable(actorName, isSelected, ImGuiSelectableFlags.SpanAllColumns))
                             {
                                 mSelectedActor = actor;
+                                viewport.SelectedActor(actor);
                             }
+                            if (ImGui.IsItemHovered() && ImGui.IsMouseDoubleClicked(0))
+                            {
+                                viewport.FrameSelectedActor(actor);
+                            }
+
                             ImGui.NextColumn();
                             ImGui.BeginDisabled();
                             ImGui.Text(name);

--- a/Fushigi/ui/widgets/LevelViewport.cs
+++ b/Fushigi/ui/widgets/LevelViewport.cs
@@ -80,6 +80,26 @@ namespace Fushigi.ui.widgets
             return new (world.X, world.Y, world.Z);
         }
 
+        public void FrameSelectedActor(CourseActor actor)
+        {
+            this.Camera.target = new Vector3(actor.mTranslation.X, actor.mTranslation.Y, 0);
+        }
+
+        public void SelectedActor(CourseActor actor)
+        {
+            if (ImGui.IsKeyDown(ImGuiKey.LeftShift))
+            {
+                mSelectedActors.Add(actor);
+                mSelectionChanged = true;
+            }
+            else
+            {
+                mSelectedActors.Clear();
+                mSelectedActors.Add(actor);
+                mSelectionChanged = true;
+            }
+        }
+
         public void HandleCameraControls(bool mouseHover, bool mouseActive)
         {
             bool isPanGesture = (ImGui.IsMouseDragging(ImGuiMouseButton.Middle)) ||


### PR DESCRIPTION
When an actor is double clicked in the list, it will frame the camera to that selected actor.
The selection view is also updated in the viewport when an actor is selected in the list.