### PR TITLE
Add simple texture loading support

### DIFF
--- a/Fushigi/Fushigi.csproj
+++ b/Fushigi/Fushigi.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Silk.NET.GLFW" Version="2.17.1" />
     <PackageReference Include="Silk.NET.Input" Version="2.17.1" />
     <PackageReference Include="Silk.NET.OpenGL.Extensions.ImGui" Version="2.17.1" />
+    <PackageReference Include="StbImageSharp" Version="2.27.13" />
     <PackageReference Include="TinyDialogsNet" Version="1.1.1" />
     <PackageReference Include="ZstdNet" Version="1.4.5" />
   </ItemGroup>

--- a/Fushigi/gl/GLImageCache.cs
+++ b/Fushigi/gl/GLImageCache.cs
@@ -1,0 +1,46 @@
+﻿using Fushigi.gl;
+using Silk.NET.Input;
+using Silk.NET.OpenGL;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fushigi.gl
+{
+    /// <summary>
+    /// Manages cached images to be added and loaded once on load. 
+    /// </summary>
+    public class GLImageCache
+    {
+        /// <summary>
+        /// A list of cached images.
+        /// </summary>
+        public Dictionary<string, uint> Images = new Dictionary<string, uint>();
+
+        public uint GetImage(GL gl, string key, string filePath)
+        {
+            if (!Images.ContainsKey(key))
+                Images.Add(key, GLTexture2D.Load(gl, filePath).ID);
+
+            return Images[key];
+        }
+
+        public void RemoveImage(GL gl, string key)
+        {
+            if (Images.ContainsKey(key))
+            {
+                gl.DeleteTexture(Images[key]);
+                Images.Remove(key);
+            }
+        }
+
+        public void Dispose(GL gl)
+        {
+            foreach (var image in Images)
+                gl.DeleteTexture(image.Value);
+            Images.Clear();
+        }
+    }
+}

--- a/Fushigi/gl/GLTexture.cs
+++ b/Fushigi/gl/GLTexture.cs
@@ -1,0 +1,46 @@
+﻿using Silk.NET.OpenGL;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fushigi.gl
+{
+    internal class GLTexture
+    {
+        public uint ID { get; private set; }
+
+        public TextureTarget Target { get; set; }
+
+        public uint Width { get; set; }
+        public uint Height { get; set; }
+
+        public InternalFormat InternalFormat { get; internal set; }
+        public PixelFormat PixelFormat { get; internal set; }
+        public PixelType PixelType { get; internal set; }
+
+        internal GL _gl { get; private set; }
+
+        public GLTexture(GL gl)
+        {
+            _gl = gl;
+            ID = gl.GenTexture();
+
+            Target = TextureTarget.Texture2D;
+            InternalFormat = InternalFormat.Rgba;
+            PixelFormat = Silk.NET.OpenGL.PixelFormat.Rgba;
+            PixelType = Silk.NET.OpenGL.PixelType.UnsignedByte;
+        }
+
+        public void Bind()
+        {
+            _gl.BindTexture(Target, ID);
+        }
+
+        public void Unbind()
+        {
+            _gl.BindTexture(Target, 0);
+        }
+    }
+}

--- a/Fushigi/gl/GLTexture2D.cs
+++ b/Fushigi/gl/GLTexture2D.cs
@@ -1,0 +1,70 @@
+﻿using Silk.NET.Core.Native;
+using Silk.NET.OpenGL;
+using Silk.NET.SDL;
+using StbImageSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fushigi.gl
+{
+    internal class GLTexture2D : GLTexture
+    {
+        public GLTexture2D(GL gl) : base(gl)
+        {
+            Target = TextureTarget.Texture2D;
+        }
+
+        public static GLTexture2D Load(GL gl, string filePath)
+        {
+            GLTexture2D tex = new GLTexture2D(gl);
+            tex.Load(filePath);
+            return tex;
+        }
+
+        public void Load(string filePath)
+        {
+            byte[] buffer = File.ReadAllBytes(filePath);
+            ImageResult image = ImageResult.FromMemory(buffer, ColorComponents.RedGreenBlueAlpha);
+
+            this.Width = (uint)image.Width;
+            this.Height = (uint)image.Height;
+
+            this.InternalFormat = InternalFormat.Rgba;
+            this.PixelFormat = Silk.NET.OpenGL.PixelFormat.Rgba;
+            this.PixelType = Silk.NET.OpenGL.PixelType.UnsignedByte;
+
+            LoadImage(image.Data);
+        }
+
+        public unsafe void LoadImage(byte[] image)
+        {
+            Bind();
+
+            fixed (byte* ptr = image)
+            {
+                _gl.TexImage2D(Target, 0, InternalFormat, Width, Height, 0,
+                    PixelFormat, PixelType, ptr);
+            }
+
+            _gl.TextureParameter(ID, TextureParameterName.TextureWrapS, (int)TextureWrapMode.Repeat);
+            _gl.TextureParameter(ID, TextureParameterName.TextureWrapT, (int)TextureWrapMode.Repeat);
+            _gl.TextureParameter(ID, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.LinearMipmapLinear);
+            _gl.TextureParameter(ID, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Linear);
+
+            _gl.GenerateMipmap(Target);
+
+            Unbind();
+        }
+
+        public void GenerateMipmaps()
+        {
+            Bind();
+            _gl.GenerateMipmap(Target);
+        }
+    }
+}

--- a/Fushigi/gl/GLTexture2D.cs
+++ b/Fushigi/gl/GLTexture2D.cs
@@ -33,10 +33,11 @@ namespace Fushigi.gl
             return tex;
         }
 
-        public void Load(string filePath)
+        public void Load(string filePath) => Load(File.ReadAllBytes(filePath));
+
+        public void Load(byte[] imageFile)
         {
-            byte[] buffer = File.ReadAllBytes(filePath);
-            ImageResult image = ImageResult.FromMemory(buffer, ColorComponents.RedGreenBlueAlpha);
+            ImageResult image = ImageResult.FromMemory(imageFile, ColorComponents.RedGreenBlueAlpha);
 
             this.Width = (uint)image.Width;
             this.Height = (uint)image.Height;

--- a/Fushigi/gl/GLTexture2D.cs
+++ b/Fushigi/gl/GLTexture2D.cs
@@ -26,6 +26,13 @@ namespace Fushigi.gl
             return tex;
         }
 
+        public static GLTexture2D Load(GL gl, int width, int height, byte[] rgba)
+        {
+            GLTexture2D tex = new GLTexture2D(gl);
+            tex.Load(width, height, rgba);
+            return tex;
+        }
+
         public void Load(string filePath)
         {
             byte[] buffer = File.ReadAllBytes(filePath);
@@ -39,6 +46,18 @@ namespace Fushigi.gl
             this.PixelType = Silk.NET.OpenGL.PixelType.UnsignedByte;
 
             LoadImage(image.Data);
+        }
+
+        public void Load(int width, int height, byte[] rgba)
+        {
+            this.Width = (uint)width;
+            this.Height = (uint)height;
+
+            this.InternalFormat = InternalFormat.Rgba;
+            this.PixelFormat = Silk.NET.OpenGL.PixelFormat.Rgba;
+            this.PixelType = Silk.NET.OpenGL.PixelType.UnsignedByte;
+
+            LoadImage(rgba);
         }
 
         public unsafe void LoadImage(byte[] image)

--- a/Fushigi/ui/widgets/CourseScene.cs
+++ b/Fushigi/ui/widgets/CourseScene.cs
@@ -389,13 +389,6 @@ namespace Fushigi.ui.widgets
                             if (ImGui.Selectable(actorName, isSelected, ImGuiSelectableFlags.SpanAllColumns))
                             {
                                 mSelectedActor = actor;
-                            }
-<<<<<<< Updated upstream
-=======
-                            //Keyboard scrolling
-                            if (ImGui.IsItemHovered() && ImGui.IsItemFocused())
-                            {
-                                mSelectedActor = actor;
                                 viewport.SelectedActor(actor);
                             }
                             if (ImGui.IsItemHovered() && ImGui.IsMouseDoubleClicked(0))
@@ -403,7 +396,6 @@ namespace Fushigi.ui.widgets
                                 viewport.FrameSelectedActor(actor);
                             }
 
->>>>>>> Stashed changes
                             ImGui.NextColumn();
                             ImGui.BeginDisabled();
                             ImGui.Text(name);

--- a/Fushigi/ui/widgets/CourseScene.cs
+++ b/Fushigi/ui/widgets/CourseScene.cs
@@ -390,6 +390,20 @@ namespace Fushigi.ui.widgets
                             {
                                 mSelectedActor = actor;
                             }
+<<<<<<< Updated upstream
+=======
+                            //Keyboard scrolling
+                            if (ImGui.IsItemHovered() && ImGui.IsItemFocused())
+                            {
+                                mSelectedActor = actor;
+                                viewport.SelectedActor(actor);
+                            }
+                            if (ImGui.IsItemHovered() && ImGui.IsMouseDoubleClicked(0))
+                            {
+                                viewport.FrameSelectedActor(actor);
+                            }
+
+>>>>>>> Stashed changes
                             ImGui.NextColumn();
                             ImGui.BeginDisabled();
                             ImGui.Text(name);


### PR DESCRIPTION
As the current build, there is no way to load images intuitively so I added in support using some classes. 

There is static functions in GLTexture2D.Load() to simply load either an image file like .png, jpg, etc and also ones to load a raw image given the width, height and raw rgba8 data. 

This also includes a GLImageCache class, which can be used for loading in stored images from a lookup and can be easily disposed of. 

Once a GLTexture2D is created, simply access the ID property and use that to use with Imgui.Image() or use it to bind for gl rendering. 