### PR TITLE
Add support for creating and editing terrain wall units.

### DIFF
--- a/Fushigi/course/CourseArea.cs
+++ b/Fushigi/course/CourseArea.cs
@@ -97,10 +97,13 @@ namespace Fushigi.course
 
             //Load rail render tools
             this.WallUnitRenders.Clear();
+            this.BeltUnitRenders.Clear();
             foreach (var unit in mUnitHolder.mUnits)
             {
                 foreach (var wall in unit.mWalls)
                     this.WallUnitRenders.Add(new UnitRailRenderer(unit, wall));
+                foreach (var wall in unit.mBeltRails)
+                    this.BeltUnitRenders.Add(new UnitRailRenderer(unit, wall));
             }
         }
 
@@ -109,11 +112,16 @@ namespace Fushigi.course
             //Save each wall back attached to the renderer
             //Clear each course unit holder
             foreach (var unit in mUnitHolder.mUnits)
+            {
                 unit.mWalls.Clear();
+                unit.mBeltRails.Clear();
+            }
 
             //Add each wall back from the renderer
             foreach (var wall_rail in WallUnitRenders)
                 wall_rail.CourseUnit.mWalls.Add(wall_rail.Save());
+            foreach (var belt_rail in BeltUnitRenders)
+                belt_rail.CourseUnit.mBeltRails.Add(belt_rail.SaveBelt());
 
             //Save using the configured mod romfs path
             Save(resource_table, Path.Combine(UserSettings.GetModRomFSPath(), "BancMapUnit"));

--- a/Fushigi/ui/Transform.cs
+++ b/Fushigi/ui/Transform.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fushigi.ui
+{
+    public class Transform
+    {
+        public Vector3 Position {  get; set; }
+        public Vector3 RotationEuler { get; set; }
+        public Vector3 Scale { get; set; } = Vector3.One;
+
+        public virtual void Update()
+        {
+
+        }
+    }
+}

--- a/Fushigi/ui/bgunit/UnitRailPointUndo.cs
+++ b/Fushigi/ui/bgunit/UnitRailPointUndo.cs
@@ -1,0 +1,85 @@
+﻿using Fushigi.ui.widgets;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace Fushigi.ui
+{
+    internal class UnitRailPointAddUndo : IRevertable
+    {
+        public string Name { get; set; }
+
+        public UnitRailRenderer Rail;
+
+        public UnitRailRenderer.RailPoint Point;
+
+        public int Index;
+
+        public UnitRailPointAddUndo(UnitRailRenderer rail, UnitRailRenderer.RailPoint point, int index = -1)
+        {
+            //Undo display name
+            Name = $"Rail Point Add";
+            //The rail to remove the point to
+            Rail = rail;
+            //The point to remove
+            Point = point;
+            Index = index;
+        }
+
+        public IRevertable Revert()
+        {
+            var index = Index != -1 ? Index : Rail.Points.IndexOf(Point);
+
+            //Revert to removale
+            if (Rail.Points.Contains(Point))
+                Rail.Points.Remove(Point);
+
+            //Create revert stack
+            return new UnitRailPointDeleteUndo(Rail, Point, index);
+        }
+    }
+
+    internal class UnitRailPointDeleteUndo : IRevertable
+    {
+        public string Name { get; set; }
+
+        public UnitRailRenderer Rail;
+
+        public UnitRailRenderer.RailPoint Point;
+
+        public int Index;
+
+        public UnitRailPointDeleteUndo(UnitRailRenderer rail, UnitRailRenderer.RailPoint point, int index = -1)
+        {
+            //Undo display name
+            Name = $"Rail Point Remove";
+            //The rail to add the point to
+            Rail = rail;
+            //The point to add
+            Point = point;
+            Index = index;
+            //Keep original point placement
+            if (rail.Points.Contains(Point) && index == -1)
+                Index = rail.Points.IndexOf(Point);
+        }
+
+        public IRevertable Revert()
+        {
+            //Revert to removale
+            if (!Rail.Points.Contains(Point))
+            {
+                if (Index != -1)
+                    Rail.Points.Insert(Index, Point);
+                else
+                    Rail.Points.Add(Point);
+            }
+
+            //Create revert stack
+            return new UnitRailPointAddUndo(Rail, Point);
+        }
+    }
+}

--- a/Fushigi/ui/bgunit/UnitRailRenderer.cs
+++ b/Fushigi/ui/bgunit/UnitRailRenderer.cs
@@ -1,0 +1,286 @@
+﻿using Fushigi.course;
+using ImGuiNET;
+using Silk.NET.Maths;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+namespace Fushigi.ui.widgets
+{
+    internal class UnitRailRenderer
+    {
+        public List<RailPoint> Points = new List<RailPoint>();
+
+        public List<RailPoint> GetSelected() => Points.Where(x => x.IsSelected).ToList();
+
+        public bool IsClosed = false;
+
+        public bool mouseDown = false;
+        public bool transformStart = false;
+
+        private Vector3 mouseDownPos;
+
+        public CourseUnit CourseUnit;
+
+        public UnitRailRenderer(CourseUnit unit, CourseUnit.ExternalRail rail)
+        {
+            CourseUnit = unit;
+
+            this.Points.Clear();
+
+            foreach (var pt in rail.mPoints)
+                Points.Add(new RailPoint(pt.Value));
+
+            IsClosed = rail.IsClosed;
+        }
+
+        public UnitRailRenderer(CourseUnit unit, CourseUnit.BeltRail rail)
+        {
+            this.Points.Clear();
+
+            foreach (var pt in rail.mPoints)
+                Points.Add(new RailPoint(pt.Value));
+
+            IsClosed = rail.IsClosed;
+        }
+
+        public CourseUnit.ExternalRail Save()
+        {
+            CourseUnit.ExternalRail rail = new CourseUnit.ExternalRail();
+
+            rail.mPoints = new List<Vector3?>();
+            foreach (var pt in Points)
+                rail.mPoints.Add(pt.Position);
+
+            rail.IsClosed = this.IsClosed;
+            return rail;
+        }
+
+        public void DeselectAll()
+        {
+            foreach (var point in Points)
+                point.IsSelected = false;
+        }
+
+        public void InsertPoint(LevelViewport viewport, RailPoint point, int index)
+        {
+            this.Points.Insert(index, point);
+            viewport.AddToUndo(new UnitRailPointAddUndo(this, point, index));
+        }
+
+        public void AddPoint(LevelViewport viewport, RailPoint point)
+        {
+            var selected = this.GetSelected();
+            if (selected.Count == 0)
+                return;
+
+            viewport.AddToUndo(new UnitRailPointAddUndo(this, point));
+        }
+
+        public void RemoveSelected(LevelViewport viewport)
+        {
+            var selected = this.GetSelected();
+            if (selected.Count == 0)
+                return;
+
+            viewport.BeginUndoCollection();
+
+            foreach (var point in selected)
+                viewport.AddToUndo(new UnitRailPointDeleteUndo(this, point));
+
+            viewport.EndUndoCollection();
+
+            foreach (var point in selected)
+                this.Points.Remove(point);
+        }
+
+        public void OnKeyDown(LevelViewport viewport)
+        {
+            if (ImGui.IsKeyPressed(ImGuiKey.Delete))
+                RemoveSelected(viewport);
+        }
+
+        public void OnMouseDown(LevelViewport viewport)
+        {
+            mouseDown = true;
+            mouseDownPos = viewport.ScreenToWorld(ImGui.GetMousePos());
+
+            var selected = GetSelected();
+
+            if (ImGui.GetIO().KeyAlt && selected.Count == 1)
+            {
+                var index = this.Points.IndexOf(selected[0]);
+                //Insert and add
+                Vector3 posVec = viewport.ScreenToWorld(ImGui.GetMousePos());
+                Vector3 pos = new(
+                     MathF.Round(posVec.X, MidpointRounding.AwayFromZero),
+                     MathF.Round(posVec.Y, MidpointRounding.AwayFromZero),
+                     selected[0].Position.Z);
+
+                DeselectAll();
+                InsertPoint(viewport, new RailPoint(pos) { IsSelected = true }, index + 1);
+            }
+            else
+            {
+                if (!ImGui.GetIO().KeyCtrl && !ImGui.GetIO().KeyShift)
+                    DeselectAll();
+            }
+
+            for (int i = 0; i < Points.Count; i++)
+            {
+                Vector3 point = Points[i].Position;
+
+                var pos2D = viewport.WorldToScreen(new(point.X, point.Y, point.Z));
+                Vector2 pnt = new(pos2D.X, pos2D.Y);
+                bool isHovered = (ImGui.GetMousePos() - pnt).Length() < 6.0f;
+
+                if (isHovered)
+                    Points[i].IsSelected = true;
+
+                Points[i].PreviousPosition = point;
+            }
+        }
+
+        public void OnMouseUp(LevelViewport viewport)
+        {
+            mouseDown = false;
+            transformStart = false;
+        }
+
+        public void OnSelecting(LevelViewport viewport)
+        {
+            if (!mouseDown) return;
+
+            Vector3 posVec = viewport.ScreenToWorld(ImGui.GetMousePos());
+            Vector3 diff = mouseDownPos - posVec;
+            if (diff.X != 0 && diff.Y != 0 && !transformStart)
+            {
+                transformStart = true;
+                //Store each selected point for undoing
+                viewport.BeginUndoCollection();
+                foreach (var point in this.GetSelected())
+                    viewport.AddToUndo(new TransformUndo(point.Transform));
+                viewport.EndUndoCollection();
+            }
+
+            for (int i = 0; i < Points.Count; i++)
+            {
+                if (transformStart && Points[i].IsSelected)
+                {
+                    diff.X = -MathF.Round(diff.X, MidpointRounding.AwayFromZero);
+                    diff.Y = -MathF.Round(diff.Y, MidpointRounding.AwayFromZero);
+                    posVec.Z = Points[i].Position.Z;
+                    Points[i].Position = Points[i].PreviousPosition + diff;
+                }
+            }
+        }
+
+        public void Render(LevelViewport viewport, ImDrawListPtr mDrawList)
+        {
+            if (ImGui.IsMouseClicked(0) && ImGui.IsMouseDown(ImGuiMouseButton.Left))
+                OnMouseDown(viewport);
+            if (ImGui.IsMouseReleased(0))
+                OnMouseUp(viewport);
+
+            if (viewport.mEditorState == LevelViewport.EditorState.Selecting)
+                OnSelecting(viewport);
+
+            OnKeyDown(viewport);
+
+            for (int i = 0; i < Points.Count; i++)
+            {
+                Vector3 point = Points[i].Position;
+                var pos2D = viewport.WorldToScreen(new(point.X, point.Y, point.Z));
+
+                //Next pos 2D
+                Vector2 nextPos2D = Vector2.Zero;
+                if (i < Points.Count - 1) //is not last point
+                {
+                    nextPos2D = viewport.WorldToScreen(new(
+                        Points[i + 1].Position.X,
+                        Points[i + 1].Position.Y,
+                        Points[i + 1].Position.Z));
+                }
+                else if (IsClosed) //last point to first if closed
+                {
+                    nextPos2D = viewport.WorldToScreen(new(
+                       Points[0].Position.X,
+                       Points[0].Position.Y,
+                       Points[0].Position.Z));
+                }
+                else //last point but not closed, draw no line
+                    continue;
+
+                uint line_color = IsValidAngle(pos2D, nextPos2D) ? 0xFFFFFFFF : 0xFF0000FF;
+                mDrawList.AddLine(pos2D, nextPos2D, line_color, 2.5f);
+            }
+
+            for (int i = 0; i < Points.Count; i++)
+            {
+                Vector3 point = Points[i].Position;
+                var pos2D = viewport.WorldToScreen(new(point.X, point.Y, point.Z));
+                Vector2 pnt = new(pos2D.X, pos2D.Y);
+
+                //Display point color
+                uint color = 0xFFFFFFFF;
+                if (Points[i].IsHovered || Points[i].IsSelected)
+                    color = ImGui.ColorConvertFloat4ToU32(new(0.84f, .437f, .437f, 1));
+
+                mDrawList.AddCircleFilled(pos2D, 6.0f, color);
+
+                bool isHovered = (ImGui.GetMousePos() - pnt).Length() < 6.0f;
+                Points[i].IsHovered = isHovered;
+            }
+        }
+
+        private bool IsValidAngle(Vector2 point1, Vector2 point2)
+        {
+            var dist = point2 - point1;
+            var angleInRadian = MathF.Atan2(dist.Y, dist.X); //angle in radian
+            var angle = angleInRadian * (180.0f / (float)System.Math.PI); //to degrees
+
+            //TODO improve check and simplify
+
+            //The game supports 30 and 45 degree angle variants
+            //Then ground (0) and wall (90)
+            float[] validAngles = new float[]
+            {
+                0, -0,
+                27, -27,
+                45, -45,
+                90, -90,
+                135,-135,
+                153,-153,
+                180,-180,
+            };
+
+            return validAngles.Contains(MathF.Round(angle));
+        }
+
+        public class RailPoint
+        {
+            public Transform Transform = new Transform();
+
+            public Vector3 Position
+            {
+                get { return Transform.Position; }
+                set { Transform.Position = value; }
+            }
+
+            public bool IsSelected { get; set; }
+            public bool IsHovered { get; set; }
+
+            //For transforming
+            public Vector3 PreviousPosition { get; set; }
+
+            public RailPoint(Vector3 pos)
+            {
+                Position = pos;
+            }
+        }
+    }
+}

--- a/Fushigi/ui/bgunit/UnitRailRenderer.cs
+++ b/Fushigi/ui/bgunit/UnitRailRenderer.cs
@@ -60,6 +60,18 @@ namespace Fushigi.ui.widgets
             return rail;
         }
 
+        public CourseUnit.BeltRail SaveBelt()
+        {
+            CourseUnit.BeltRail rail = new CourseUnit.BeltRail();
+
+            rail.mPoints = new List<Vector3?>();
+            foreach (var pt in Points)
+                rail.mPoints.Add(pt.Position);
+
+            rail.IsClosed = this.IsClosed;
+            return rail;
+        }
+
         public void DeselectAll()
         {
             foreach (var point in Points)

--- a/Fushigi/ui/undo/IRevertable.cs
+++ b/Fushigi/ui/undo/IRevertable.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fushigi.ui
+{
+    public interface IRevertable
+    {
+        string Name { get; }
+
+        IRevertable Revert();
+    }
+}

--- a/Fushigi/ui/undo/TransformUndo.cs
+++ b/Fushigi/ui/undo/TransformUndo.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace Fushigi.ui
+{
+    public class TransformUndo : IRevertable
+    {
+        public string Name { get; set; }
+
+        public Transform Transform;
+
+        public Vector3 PreviousPosition;
+        public Vector3 PreviousRotation;
+        public Vector3 PreviousScale;
+
+        public TransformUndo(Transform transform, string name = "Transform")
+        {
+            //Undo display name
+            Name = name;
+            //The transform to update
+            Transform = transform;
+            //The state to revert to
+            PreviousPosition = transform.Position;
+            PreviousRotation = transform.RotationEuler;
+            PreviousScale = transform.Scale;
+        }
+
+        public IRevertable Revert()
+        {
+            //Revert transform instance
+            Transform.Position = this.PreviousPosition;
+            Transform.RotationEuler = this.PreviousRotation;
+            Transform.Scale = this.PreviousScale;
+            Transform.Update();
+
+            //Create revert stack
+            return new TransformUndo(Transform);
+        }
+    }
+}

--- a/Fushigi/ui/undo/UndoRedo.cs
+++ b/Fushigi/ui/undo/UndoRedo.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Fushigi.ui
+{
+    public class UndoHandler
+    {
+        public struct RedoEntry
+        {
+            public IRevertable undoable;
+            public IRevertable redoable;
+        }
+
+        protected Stack<IRevertable> undoStack = new Stack<IRevertable>();
+        protected Stack<RedoEntry> redoStack = new Stack<RedoEntry>();
+
+        //For collection reverting
+        List<IRevertable> undoCollection = null;
+
+        /// <summary>
+        /// Starts adding called AddToUndo() into a collection.
+        /// Must be ended using EndUndoCollection().
+        /// </summary>
+        public void BeginUndoCollection() {
+            //Set a collection to add incomming undo operations
+            undoCollection = new List<IRevertable>();
+        }
+
+        /// <summary>
+        /// Ends the undo collection.
+        /// </summary>
+        public void EndUndoCollection(string name = "Multi Operation") {
+            //Undo ended already, skip
+            if (undoCollection == null)
+                return;
+
+            //Create a revertable like a normal undo operation but with batch revertables
+            if (undoCollection.Count > 0) {
+                undoStack.Push(new MultiRevertable(name, undoCollection.ToArray()));
+                redoStack.Clear();
+            }
+            //Reset the undo collection to not be used again
+            undoCollection = null;
+        }
+
+        public void AddToUndo(List<IRevertable> undoCollection, string name = "Multi Operation")
+        {
+            if (undoCollection == null)
+                return;
+
+            //Create a revertable like a normal undo operation but with batch revertables
+            if (undoCollection.Count > 0) {
+                undoStack.Push(new MultiRevertable(name, undoCollection.ToArray()));
+                redoStack.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Adds a revertable action to the undo stack.
+        /// </summary>
+        /// <param name="revertable"></param>
+        public void AddToUndo(IRevertable revertable)
+        {
+            //Batch undo collection operation
+            if (undoCollection != null)
+                undoCollection.Add(revertable);
+            else
+            {
+                //Normal undo operation
+                undoStack.Push(revertable);
+                redoStack.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Undo the current operation in the undo stack.
+        /// </summary>
+        public void Undo()
+        { 
+            if (undoStack.Count > 0)
+            {
+                var undoable = undoStack.Pop();
+                var redoable = undoable.Revert();
+                redoStack.Push(new RedoEntry { undoable = undoable, redoable = redoable });
+            }
+        }
+
+        /// <summary>
+        /// Redo the current operation in the redo stack.
+        /// </summary>
+        public void Redo()
+        {
+            if (redoStack.Count > 0)
+            {
+                var entry = redoStack.Pop();
+                entry.redoable.Revert();
+                undoStack.Push(entry.undoable);
+            }
+        }
+
+        public class MultiRevertable : IRevertable
+        {
+            public string Name { get; private set; }
+
+            IRevertable[] revertables;
+
+            public MultiRevertable(string name, IRevertable[] revertables)
+            {
+                this.Name = name;
+                this.revertables = revertables;
+            }
+
+            public IRevertable Revert()
+            {
+                IRevertable[] newRevertables = new IRevertable[revertables.Length];
+
+                int _i = 0;
+                for (int i = revertables.Length - 1; i >= 0; i--) //Revertables are meant to be reverted in the reverse order (First In Last Out)
+                    newRevertables[_i++] = revertables[i].Revert();
+
+                return new MultiRevertable(Name, newRevertables);
+            }
+        }
+    }
+}

--- a/Fushigi/ui/widgets/LevelViewport.cs
+++ b/Fushigi/ui/widgets/LevelViewport.cs
@@ -472,7 +472,34 @@ namespace Fushigi.ui.widgets
             Vector3? newHoveredPoint = null;
 
             foreach (var wall in this.mArea.WallUnitRenders)
-                wall.Render(this, mDrawList); 
+                wall.Render(this, mDrawList);
+
+            //Hide belt for now. TODO how should this be handled?
+            //foreach (var belt in this.mArea.BeltUnitRenders)
+            //    belt.Render(this, mDrawList);
+
+            if (mArea.mRailHolder.mRails.Count > 0)
+            {
+                foreach (CourseRail rail in mArea.mRailHolder.mRails)
+                {
+                    List<Vector2> pointsList = [];
+                    foreach (CourseRail.CourseRailPoint pnt in rail.mPoints)
+                    {
+                        var pos2D = WorldToScreen(new(pnt.mTranslate.X, pnt.mTranslate.Y, pnt.mTranslate.Z));
+                        mDrawList.AddCircleFilled(pos2D, pointSize, (uint)System.Drawing.Color.HotPink.ToArgb());
+                        pointsList.Add(pos2D);
+                    }
+                    for (int i = 0; i < pointsList.Count - 1; i++)
+                    {
+                        mDrawList.AddLine(pointsList[i], pointsList[i + 1], (uint)System.Drawing.Color.HotPink.ToArgb(), 2.5f);
+                    }
+                    bool isClosed = rail.mIsClosed;
+                    if (isClosed)
+                    {
+                        mDrawList.AddLine(pointsList[pointsList.Count - 1], pointsList[0], (uint)System.Drawing.Color.HotPink.ToArgb(), 2.5f);
+                    }
+                }
+            }
 
             CourseActor? newHoveredActor = null;
 


### PR DESCRIPTION
This is initial support for creating and editing wall rails. 

![image](https://github.com/shibbo/Fushigi/assets/13475262/008fcfda-c706-4938-bd68-fd3e03cc3091)

Walls are now stored under a list of WallUnitRenderers in CourseArea. These control all functionality for editing the wall units.
Beltrails have a similar treatment but I decided to hide them for now. I am not sure how we should handle these yet.

This also adds support for undo/redo handling by using CTRL + Z and CTRL + R for redo. 
Simply creating a IRevertable state, then adding to AddToUndo in the viewport to use. I currently have both transform, add, and delete states for the points for an idea on how I added this. This also includes a begin/end undo states for doing collection of states at once.