### PR TITLE
Fix crash on setting wrong RomFS path

### DIFF
--- a/Fushigi/ui/widgets/Preferences.cs
+++ b/Fushigi/ui/widgets/Preferences.cs
@@ -29,9 +29,15 @@ namespace Fushigi.ui.widgets
                     )
                 {
                     romfsTouched = true;
+ 
+                    UserSettings.SetRomFSPath(romfs);
+
+                    if (!RomFS.IsValidRoot(romfs))
+                    {
+                        return;
+                    }
 
                     RomFS.SetRoot(romfs);
-                    UserSettings.SetRomFSPath(romfs);
                     
                     /* if our parameter database isn't set, set it */
                     if (!ParamDB.sIsInit)


### PR DESCRIPTION
Add guard clause that stops RomFS.SetRoot and ParamDB.Load to run if the inputted romfs path is wrong. This was causing a crash for new users setting a bad path, would crash on ParamDB.Load trying to read a file from the romfs path that wasn't there.