### PR TITLE
Tiny Mac Fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Fushigi.Byml/bin/*
 Fushigi.Byml/obj/*
 SARC/bin/*
 SARC/obj/*
+.DS_Store

--- a/Fushigi/param/ParamLoader.cs
+++ b/Fushigi/param/ParamLoader.cs
@@ -15,9 +15,12 @@ namespace Fushigi.param
             mParams = new Dictionary<string, ParamHolder>();
             var nodes = JsonNode.Parse(
                 File.ReadAllText(
-                    Path.Combine("res", "AreaParam.json")
+                    Path.Combine(
+                        AppDomain.CurrentDomain.BaseDirectory,
+                        Path.Combine("res", "AreaParam.json")
                     )
-                ).AsObject();
+                )
+            ).AsObject();
             ParamHolder areaParms = new ParamHolder();
 
             foreach (KeyValuePair<string, JsonNode> obj in nodes)


### PR DESCRIPTION
 - Removes .DS_Store files for Mac helpers.
 - Redirects the search for the AreaParam.json to be the Application's BaseDirectory instead of $HOME. If there is a better way, please let me know.