### PR TITLE
Switch to ZstdSharp and Mac Build options

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,13 +36,15 @@ jobs:
       run: dotnet add Fushigi/Fushigi.csproj package Silk.NET.OpenGL.Extensions.ImGui  --version 2.17.1 
     - name: Install StbImageSharp
       run: dotnet add Fushigi/Fushigi.csproj package StbImageSharp 
-    - name: Install ZstdNet
+    - name: Install ZstdSharp
       run: dotnet add Fushigi/Fushigi.csproj package ZstdSharp.Port
     - name: Restore dependencies
       run: dotnet restore Fushigi/Fushigi.sln
     - name: Build
       run: dotnet build Fushigi/Fushigi.sln --no-restore 
-    - name: Build Mac Silicon
-      run: dotnet build Fushigi/Fushigi.sln -r osx-arm64 --no-restore
-    - name: Build Mac x64
-      run: dotnet build Fushigi/Fushigi.sln -r osx-x64 --no-restore
+    - name: Publish Mac Silicon
+      run: dotnet publish Fushigi/Fushigi.sln -r osx-arm64 --no-restore
+    - name: Publish Mac x64
+      run: dotnet publish Fushigi/Fushigi.sln -r osx-x64 --no-restore
+    - name: Publish Linux x64
+      run: dotnet publish Fushigi/Fushigi.sln --os linux --no-restore

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -42,11 +42,15 @@ jobs:
       run: dotnet restore Fushigi/Fushigi.sln
     - name: Build
       run: dotnet build Fushigi/Fushigi.sln --no-restore 
-    - name: Switch Build Targets to MacOS
-      run: dotnet restore
+    - name: Restore dependancies for MacOS Silicon
+      run: dotnet restore -r osx-arm64 Fushigi/Fushigi.sln
     - name: Publish Mac Silicon
       run: dotnet publish Fushigi/Fushigi.sln -r osx-arm64 --no-restore
+    - name: Restore dependancies for MacOS x64
+      run: dotnet restore -r osx-x64 Fushigi/Fushigi.sln
     - name: Publish Mac x64
       run: dotnet publish Fushigi/Fushigi.sln -r osx-x64 --no-restore
+    - name: Restore dependancies for Linux
+      run: dotnet restore -r linux Fushigi/Fushigi.sln
     - name: Publish Linux x64
       run: dotnet publish Fushigi/Fushigi.sln --os linux --no-restore

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -51,6 +51,6 @@ jobs:
     - name: Publish Mac x64
       run: dotnet publish Fushigi/Fushigi.sln -r osx-x64 --no-restore
     - name: Restore dependancies for Linux
-      run: dotnet restore -r linux Fushigi/Fushigi.sln
+      run: dotnet restore -r linux-x64 Fushigi/Fushigi.sln
     - name: Publish Linux x64
-      run: dotnet publish Fushigi/Fushigi.sln --os linux --no-restore
+      run: dotnet publish Fushigi/Fushigi.sln -r linux-x64 --no-restore

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Build
       run: dotnet build Fushigi/Fushigi.sln --no-restore 
     - name: Switch Build Targets to MacOS
-      run: dotnet workload install macos
+      run: dotnet restore
     - name: Publish Mac Silicon
       run: dotnet publish Fushigi/Fushigi.sln -r osx-arm64 --no-restore
     - name: Publish Mac x64

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -42,6 +42,10 @@ jobs:
       run: dotnet restore Fushigi/Fushigi.sln
     - name: Build
       run: dotnet build Fushigi/Fushigi.sln --no-restore 
+    - name: Switch Build Targets to MacOS
+      run: dotnet workload install macos
+    - name: Refresh Workflow
+      run: dotnet workload restore
     - name: Publish Mac Silicon
       run: dotnet publish Fushigi/Fushigi.sln -r osx-arm64 --no-restore
     - name: Publish Mac x64

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,8 +37,12 @@ jobs:
     - name: Install StbImageSharp
       run: dotnet add Fushigi/Fushigi.csproj package StbImageSharp 
     - name: Install ZstdNet
-      run: dotnet add Fushigi/Fushigi.csproj package ZstdNet 
+      run: dotnet add Fushigi/Fushigi.csproj package ZstdSharp.Port
     - name: Restore dependencies
       run: dotnet restore Fushigi/Fushigi.sln
     - name: Build
       run: dotnet build Fushigi/Fushigi.sln --no-restore 
+    - name: Build Mac Silicon
+      run: dotnet build Fushigi/Fushigi.sln -r osx-arm64 --no-restore
+    - name: Build Mac x64
+      run: dotnet build Fushigi/Fushigi.sln -r osx-x64 --no-restore

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -44,8 +44,6 @@ jobs:
       run: dotnet build Fushigi/Fushigi.sln --no-restore 
     - name: Switch Build Targets to MacOS
       run: dotnet workload install macos
-    - name: Refresh Workflow
-      run: dotnet workload restore
     - name: Publish Mac Silicon
       run: dotnet publish Fushigi/Fushigi.sln -r osx-arm64 --no-restore
     - name: Publish Mac x64

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .vs/*
 Fushigi/.vs/*
+.idea/*
+Fushigi/.idea/*
 Fushigi/bin/*
 Fushigi/obj/*
 Fushigi.Byml/.vs/*

--- a/Fushigi/Fushigi.csproj
+++ b/Fushigi/Fushigi.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Silk.NET.Input" Version="2.17.1" />
     <PackageReference Include="Silk.NET.OpenGL.Extensions.ImGui" Version="2.17.1" />
     <PackageReference Include="StbImageSharp" Version="2.27.13" />
-    <PackageReference Include="ZstdNet" Version="1.4.5" />
+    <PackageReference Include="ZstdSharp.Port" Version="0.7.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Fushigi/course/CourseArea.cs
+++ b/Fushigi/course/CourseArea.cs
@@ -10,7 +10,6 @@ using System.Net.Mime;
 using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
-using ZstdNet;
 
 namespace Fushigi.course
 {

--- a/Fushigi/util/FileUtil.cs
+++ b/Fushigi/util/FileUtil.cs
@@ -37,9 +37,10 @@ namespace Fushigi.util
             if (!IsFileCompressed(fileBytes)) {
                 throw new Exception("FileUtil::DecompressData -- File not ZSTD Compressed.");
             }
-            using (var decompressor = new ZstdNet.Decompressor())
+            using (var decompressor = new ZstdSharp.Decompressor())
             {
-                decompressedData = decompressor.Unwrap(fileBytes);
+                
+                decompressedData = decompressor.Unwrap(new System.Span<byte>(fileBytes)).ToArray();
             }
 
             return decompressedData;
@@ -63,10 +64,10 @@ namespace Fushigi.util
         public static byte[] CompressData(byte[] fileBytes)
         {
             byte[] compressedData;
-
-            using (var compressor = new ZstdNet.Compressor(new ZstdNet.CompressionOptions(19)))
+            
+            using (var compressor = new ZstdSharp.Compressor(19))
             {
-                compressedData = compressor.Wrap(fileBytes);
+                compressedData = compressor.Wrap(new System.Span<byte>(fileBytes)).ToArray();
             }
 
             return compressedData;


### PR DESCRIPTION
 - ZstdNet was switched for ZstdSharp.Port
 - Added .idea for the gitignore
 - Added options to build for Mac x64 and Arm to the workflows.