### PR TITLE
Replace Alt + LMB pan gesture with Shift + LMB.

### DIFF
--- a/Fushigi/ui/widgets/LevelViewport.cs
+++ b/Fushigi/ui/widgets/LevelViewport.cs
@@ -128,7 +128,7 @@ namespace Fushigi.ui.widgets
         public void HandleCameraControls(bool mouseHover, bool mouseActive)
         {
             bool isPanGesture = (ImGui.IsMouseDragging(ImGuiMouseButton.Middle)) ||
-                (ImGui.IsMouseDragging(ImGuiMouseButton.Left) && ImGui.GetIO().KeyAlt);
+                (ImGui.IsMouseDragging(ImGuiMouseButton.Left) && ImGui.GetIO().KeyShift);
 
             if (mouseActive && isPanGesture)
             {


### PR DESCRIPTION
This should improve the general UX of Fushigi's viewport panning. The previous panning used Alt + LMB as a second gesture, however this caused some issues because the gesture was also being used for adding wall points.

Shift is a bigger key than Alt, it's easier to manage with your hands, and also, I can't use Space as a key (thanks Silk.Net ImGui mappings)