### PR TITLE
Added so that if you press the button of a link destination so that you auto select the linked Actor

### DIFF
--- a/Fushigi/ui/widgets/CourseScene.cs
+++ b/Fushigi/ui/widgets/CourseScene.cs
@@ -496,7 +496,7 @@ namespace Fushigi.ui.widgets
                         {
                             if (ImGui.Button(destActor.mName, new Vector2(ImGui.GetContentRegionAvail().X, 0)))
                             {
-
+                                mSelectedActor = destActor;
                             }
                         }
                         else


### PR DESCRIPTION
Small but important change, so if you go through the links of an actor and you want to go to an linked actor you just need to click
on the button with their actor name and you auto select it