### PR TITLE
Undo History and Actor Box Points

### DIFF
--- a/Fushigi/ui/widgets/LevelViewport.cs
+++ b/Fushigi/ui/widgets/LevelViewport.cs
@@ -931,8 +931,11 @@ namespace Fushigi.ui.widgets
 
                         for (int i = 0; i < 4; i++)
                         {
-                            mDrawList.AddCircleFilled(s_actorRectPolygon[i],
-                                pointSize, color);
+                            if (mEditContext.IsSelected(actor))
+                            {
+                                mDrawList.AddCircleFilled(s_actorRectPolygon[i],
+                                    pointSize, color);
+                            }
                             mDrawList.AddLine(
                                 s_actorRectPolygon[i],
                                 s_actorRectPolygon[(i + 1) % 4],

--- a/Fushigi/ui/widgets/UndoWindow.cs
+++ b/Fushigi/ui/widgets/UndoWindow.cs
@@ -47,8 +47,7 @@ namespace Fushigi.ui.widgets
                 for (var i = 0; i < context.GetRedoUndoStack().Count(); i++)
                 {
                     var op = context.GetRedoUndoStack().ElementAt(i);
-                    ImGui.PushStyleColor(ImGuiCol.Text, ImGui.GetStyle().Colors[(int)ImGuiCol.TextDisabled]);
-                    ImGui.PushID(i);
+                    ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(1, 1, 1, 0.5f));
                     if (ImGui.Selectable(op.Name+"##"+i))
                     {
                         for(var a = 0; a <=  i; a++)
@@ -56,7 +55,6 @@ namespace Fushigi.ui.widgets
                             context.Redo();
                         }
                     }
-                    ImGui.PopID();
                     ImGui.PopStyleColor();
                 }
                 ImGui.End();

--- a/Fushigi/ui/widgets/UndoWindow.cs
+++ b/Fushigi/ui/widgets/UndoWindow.cs
@@ -14,8 +14,6 @@ namespace Fushigi.ui.widgets
     {
         public void Render(CourseAreaEditContext context)
         {
-            var undos = new Dictionary<int, string>();
-            var redos = new Dictionary<int, string>();
             if (ImGui.Begin("History"))
             {
                 if (ImGui.Button($"{IconUtil.ICON_UNDO}"))

--- a/Fushigi/ui/widgets/UndoWindow.cs
+++ b/Fushigi/ui/widgets/UndoWindow.cs
@@ -47,7 +47,8 @@ namespace Fushigi.ui.widgets
                 for (var i = 0; i < context.GetRedoUndoStack().Count(); i++)
                 {
                     var op = context.GetRedoUndoStack().ElementAt(i);
-                    ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(1, 1, 1, 0.5f));
+                    ImGui.PushStyleColor(ImGuiCol.Text, ImGui.GetStyle().Colors[(int)ImGuiCol.TextDisabled]);
+                    ImGui.PushID(i);
                     if (ImGui.Selectable(op.Name+"##"+i))
                     {
                         for(var a = 0; a <=  i; a++)
@@ -55,6 +56,7 @@ namespace Fushigi.ui.widgets
                             context.Redo();
                         }
                     }
+                    ImGui.PopID();
                     ImGui.PopStyleColor();
                 }
                 ImGui.End();

--- a/Fushigi/ui/widgets/UndoWindow.cs
+++ b/Fushigi/ui/widgets/UndoWindow.cs
@@ -1,8 +1,10 @@
 ﻿using Fushigi.util;
 using ImGuiNET;
+using Microsoft.VisualBasic;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -12,6 +14,8 @@ namespace Fushigi.ui.widgets
     {
         public void Render(CourseAreaEditContext context)
         {
+            var undos = new Dictionary<int, string>();
+            var redos = new Dictionary<int, string>();
             if (ImGui.Begin("History"))
             {
                 if (ImGui.Button($"{IconUtil.ICON_UNDO}"))
@@ -23,24 +27,37 @@ namespace Fushigi.ui.widgets
                 {
                     context.Redo();
                 }
-                foreach (var op in context.GetUndoStack().Reverse())
+                if (ImGui.Selectable($"{IconUtil.ICON_FILE_DOWNLOAD}"+"Course Loaded", !context.GetUndoStack().Any()))
                 {
-                    bool selected = context.GetLastAction() == op;
-                    if (ImGui.Selectable(op.Name, selected))
+                    for(var a = context.GetUndoStack().Count()-1; a >= 0; a--)
                     {
-
+                        context.Undo();
                     }
                 }
-                foreach (var op in context.GetRedoUndoStack())
+                for (var i = 0; i < context.GetUndoStack().Count(); i++)
                 {
-                    ImGui.BeginDisabled();
-
+                    var op = context.GetUndoStack().Reverse().ElementAt(i);
                     bool selected = context.GetLastAction() == op;
-                    if (ImGui.Selectable(op.Name, selected))
+                    if (ImGui.Selectable(op.Name+"##"+i, selected))
                     {
-
+                        for(var a = context.GetUndoStack().Count()-1; a > i; a--)
+                        {
+                            context.Undo();
+                        }
                     }
-                    ImGui.EndDisabled();
+                }
+                for (var i = 0; i < context.GetRedoUndoStack().Count(); i++)
+                {
+                    var op = context.GetRedoUndoStack().ElementAt(i);
+                    ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(1, 1, 1, 0.5f));
+                    if (ImGui.Selectable(op.Name+"##"+i))
+                    {
+                        for(var a = 0; a <=  i; a++)
+                        {
+                            context.Redo();
+                        }
+                    }
+                    ImGui.PopStyleColor();
                 }
                 ImGui.End();
             }


### PR DESCRIPTION
Clicking actions in the History will revert to when that action took place, includes a "Course Loaded" action to easily undo all changes

Also actor boxes now only display their corner points when selected.