### PR TITLE
Scale WASD panning speed with zoom

### DIFF
--- a/Fushigi/ui/widgets/LevelViewport.cs
+++ b/Fushigi/ui/widgets/LevelViewport.cs
@@ -166,24 +166,30 @@ namespace Fushigi.ui.widgets
             {
                 Camera.Distance *= MathF.Pow(2, -ImGui.GetIO().MouseWheel / 10);
 
+                // Default camera distance is 10, so speed is constant until 0.5 at 20
+                const float baseCameraSpeed = 0.25f;
+                const float scalingRate = 10.0f;
+                var zoomSpeedFactor = Math.Max(Camera.Distance / scalingRate, 1);
+                var zoomedCameraSpeed = MathF.Floor(zoomSpeedFactor) * baseCameraSpeed;
+
                 if (ImGui.IsKeyDown(ImGuiKey.LeftArrow) || ImGui.IsKeyDown(ImGuiKey.A))
                 {
-                    Camera.Target.X -= 0.25f;
+                    Camera.Target.X -= zoomedCameraSpeed;
                 }
 
                 if (ImGui.IsKeyDown(ImGuiKey.RightArrow) || ImGui.IsKeyDown(ImGuiKey.D))
                 {
-                    Camera.Target.X += 0.25f;
+                    Camera.Target.X += zoomedCameraSpeed;
                 }
 
                 if (ImGui.IsKeyDown(ImGuiKey.UpArrow) || ImGui.IsKeyDown(ImGuiKey.W))
                 {
-                    Camera.Target.Y += 0.25f;
+                    Camera.Target.Y += zoomedCameraSpeed;
                 }
 
                 if (ImGui.IsKeyDown(ImGuiKey.DownArrow) || ImGui.IsKeyDown(ImGuiKey.S))
                 {
-                    Camera.Target.Y -= 0.25f;
+                    Camera.Target.Y -= zoomedCameraSpeed;
                 }
             }
         }


### PR DESCRIPTION
- 0.25 speed was painfully slow when zoomed out
- this preserves existing speed around the default+max zoom and speeds up in 0.25 increments every 10 distance, felt good to me
- real speed is (still) fps dependent, notice the higher speed at the end of this clip as there's less to render
- distance + speed are peeking out at the very bottom of this scuffed clip

https://github.com/shibbo/Fushigi/assets/137466401/90eaebbe-3c15-4725-8ea3-fe6a07e99cdf

