### PR TITLE
Improve Course Select Loading

### DIFF
--- a/Fushigi/RomFS.cs
+++ b/Fushigi/RomFS.cs
@@ -13,7 +13,7 @@ namespace Fushigi
 {
     public class RomFS
     {
-        public static void SetRoot(string root)
+        public static void SetRoot(string root, GL gl)
         {           
             if (!IsValidRoot(root))
             {
@@ -22,6 +22,7 @@ namespace Fushigi
 
             sRomFSRoot = root;
             CacheCourseFiles();
+            CacheCourseThumbnails(gl);
         }
 
         public static string GetRoot()
@@ -120,6 +121,14 @@ namespace Fushigi
             }
         }
 
+        public static void CacheCourseThumbnails(GL gl)
+        {
+            foreach (var world in sCourseEntries.Keys)
+            {
+                CacheCourseThumbnails(gl, world);
+            }
+        }
+
         public static void CacheCourseThumbnails(GL gl, string world)
         {
             var thumbnailFolder = Path.Combine(GetRoot(), "UI", "Tex", "Thumbnail");
@@ -138,8 +147,6 @@ namespace Fushigi
                 {
                     path = Path.Combine(thumbnailFolder, "Default.bntx.zs");
                 }
-
-                Console.WriteLine($"Thumbnail - {course}");
 
                 byte[] fileBytes = FileUtil.DecompressFile(path);
                 var bntx = new BntxFile(new MemoryStream(fileBytes));

--- a/Fushigi/RomFS.cs
+++ b/Fushigi/RomFS.cs
@@ -133,10 +133,10 @@ namespace Fushigi
         {
             var thumbnailFolder = Path.Combine(GetRoot(), "UI", "Tex", "Thumbnail");
 
-            foreach (var course in sCourseEntries[world].courseEntries.Keys)
+            foreach (var course in sCourseEntries[world].courseEntries!.Keys)
             {
                 // Skip the process if this course's thumbnail is already cached
-                if (sCourseEntries[world].courseEntries[course].thumbnail != null)
+                if (sCourseEntries[world].courseEntries![course].thumbnail != null)
                 {
                     continue;
                 }
@@ -152,7 +152,7 @@ namespace Fushigi
                 var bntx = new BntxFile(new MemoryStream(fileBytes));
                 var render = new BfresTextureRender(gl, bntx.Textures[0]);
 
-                sCourseEntries[world].courseEntries[course].thumbnail = render;
+                sCourseEntries[world].courseEntries![course].thumbnail = render;
             }
         }
 
@@ -160,12 +160,12 @@ namespace Fushigi
         {
             public class CourseEntry
             {
-                public string name;
-                public BfresTextureRender thumbnail;
+                public string? name;
+                public BfresTextureRender? thumbnail;
             }
 
-            public string name;
-            public Dictionary<string,  CourseEntry> courseEntries;
+            public string? name;
+            public Dictionary<string, CourseEntry>? courseEntries;
         }
 
         

--- a/Fushigi/ui/MainWindow.cs
+++ b/Fushigi/ui/MainWindow.cs
@@ -127,6 +127,21 @@ namespace Fushigi.ui
             {
                 RomFS.SetRoot(romFSPath, gl);
                 ChildActorParam.Load();
+
+                if (!ParamDB.sIsInit)
+                {
+                    Console.WriteLine("Parameter database needs to be initialized...");
+                    mIsGeneratingParamDB = true;
+                }
+
+                string? latestCourse = UserSettings.GetLatestCourse();
+                if (latestCourse != null && ParamDB.sIsInit)
+                {
+                    mCurrentCourseName = latestCourse;
+                    mSelectedCourseScene = new(new(mCurrentCourseName), gl);
+                    mIsChoosingPreferences = false;
+                    mIsWelcome = false;
+                }
             }
 
             ActorIconLoader.Init();
@@ -138,20 +153,7 @@ namespace Fushigi.ui
                 mIsWelcome = false;
             }
 
-            if (!ParamDB.sIsInit && !string.IsNullOrEmpty(RomFS.GetRoot()))
-            {
-                Console.WriteLine("Parameter database needs to be initialized...");
-                mIsGeneratingParamDB = true;
-            }
-
-            string? latestCourse = UserSettings.GetLatestCourse();
-            if (latestCourse != null && ParamDB.sIsInit)
-            {
-                mCurrentCourseName = latestCourse;
-                mSelectedCourseScene = new(new(mCurrentCourseName), gl);
-                mIsChoosingPreferences = false;
-                mIsWelcome = false;
-            }
+             
         }
 
         void DrawMainMenu(GL gl)

--- a/Fushigi/ui/MainWindow.cs
+++ b/Fushigi/ui/MainWindow.cs
@@ -125,7 +125,7 @@ namespace Fushigi.ui
             string romFSPath = UserSettings.GetRomFSPath();
             if (RomFS.IsValidRoot(romFSPath))
             {
-                RomFS.SetRoot(romFSPath);
+                RomFS.SetRoot(romFSPath, gl);
                 ChildActorParam.Load();
             }
 
@@ -333,7 +333,7 @@ namespace Fushigi.ui
 
                 if (mIsChoosingPreferences)
                 {
-                    Preferences.Draw(ref mIsChoosingPreferences);
+                    Preferences.Draw(ref mIsChoosingPreferences, gl);
                 }
 
                 if (mIsWelcome)

--- a/Fushigi/ui/widgets/CourseSelect.cs
+++ b/Fushigi/ui/widgets/CourseSelect.cs
@@ -103,7 +103,7 @@ namespace Fushigi.ui.widgets
 
             float em = ImGui.GetFrameHeight();
 
-            foreach (var course in courses)
+            foreach (var course in courses!)
             {
                 ImGui.PushID(course.Key);
                 ImGui.TableNextColumn();
@@ -127,7 +127,7 @@ namespace Fushigi.ui.widgets
 
                 dl.PushClipRect(min, max, true);
 
-                course.Value.thumbnail.CheckState(false);
+                course.Value.thumbnail!.CheckState(false);
                 dl.AddImage((IntPtr)course.Value.thumbnail.ID,
                     (min + max - thumbnailSize) / 2 - new Vector2(0, em * 1.25f),
                     (min + max + thumbnailSize) / 2 - new Vector2(0, em * 1.25f));

--- a/Fushigi/ui/widgets/CourseSelect.cs
+++ b/Fushigi/ui/widgets/CourseSelect.cs
@@ -99,7 +99,6 @@ namespace Fushigi.ui.widgets
             }
             ImGui.TableNextRow();
 
-            RomFS.CacheCourseThumbnails(gl, selectedWorld!);
             var courses = RomFS.GetCourseEntries()[selectedWorld!].courseEntries;
 
             float em = ImGui.GetFrameHeight();

--- a/Fushigi/ui/widgets/Preferences.cs
+++ b/Fushigi/ui/widgets/Preferences.cs
@@ -1,6 +1,7 @@
 ﻿using Fushigi.param;
 using Fushigi.util;
 using ImGuiNET;
+using Silk.NET.OpenGL;
 using System.Numerics;
 
 namespace Fushigi.ui.widgets
@@ -12,7 +13,7 @@ namespace Fushigi.ui.widgets
         static bool modRomfsTouched = false;
         static bool mIsGeneratingParamDB = false;
 
-        public static void Draw(ref bool continueDisplay)
+        public static void Draw(ref bool continueDisplay, GL gl)
         {
             if (mIsGeneratingParamDB)
             {
@@ -43,7 +44,7 @@ namespace Fushigi.ui.widgets
                         return;
                     }
 
-                    RomFS.SetRoot(romfs);
+                    RomFS.SetRoot(romfs, gl);
                     ChildActorParam.Load();
 
                     /* if our parameter database isn't set, set it */


### PR DESCRIPTION
- Thumbnail loading done on romfs path set
  - Better choice now that texture loading is done in the background
  - Does not add significant time to start up (0.3s - 1s at most)
  - No more hanging on world select, improved performance
  - Thumbnails are likely fully loaded by the time the user opens course select, but will just be black rectangles until then
- Fix romfs path tampering crash
  - There was a crash that would occur if a user tampered with their romfs path outside of the program and had opened a course before
  - Certain things like the paramDB and latestCourse will now only load if the romfs path is valid
  - If the saved romfs path is no longer valid on startup, the preferences window will be open so the user can reset it