### PR TITLE
Fix adding multiple rail points on click

### DIFF
--- a/Fushigi/ui/widgets/LevelViewport.cs
+++ b/Fushigi/ui/widgets/LevelViewport.cs
@@ -773,20 +773,15 @@ namespace Fushigi.ui.widgets
                         }
                     }
                 }
-
-                ISceneObject? newHoveredSceneObj = null;
-
-                areaScene.ForEach<IViewportDrawable>(obj =>
-                {
-                    bool isNewHoveredObj = false;
-                    obj.Draw2D(mEditContext, this, mDrawList, ref isNewHoveredObj);
-                    if (isNewHoveredObj)
-                        newHoveredObject = obj;
-                });
-
-                if (newHoveredSceneObj is not null)
-                    newHoveredObject = newHoveredSceneObj;
             }
+
+            areaScene.ForEach<IViewportDrawable>(obj =>
+            {
+                bool isNewHoveredObj = false;
+                obj.Draw2D(mEditContext, this, mDrawList, ref isNewHoveredObj);
+                if (isNewHoveredObj)
+                    newHoveredObject = obj;
+            });
 
             if (mArea.mRailHolder.mRails.Count > 0)
             {


### PR DESCRIPTION
The areaScene objects Draw2D was being called once per tile unit selected. This caused a bug where alt clicking would place multiple rail points in the same spot instead of just one. It was probably causing even more issues. This code was removed from the foreach loop it was in, and is now called once per frame as intended, and everything works great.