### PR TITLE
fix access of files relative to the program directory

### DIFF
--- a/Fushigi/Program.cs
+++ b/Fushigi/Program.cs
@@ -35,7 +35,7 @@ Console.WriteLine("Checking for imgui.ini");
 if (!Path.Exists("imgui.ini"))
 {
   Console.WriteLine("Creating imgui.ini...");
-  File.WriteAllText("imgui.ini", File.ReadAllText(Path.Combine("res", "imgui-default.ini")));
+  File.WriteAllText("imgui.ini", File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "res", "imgui-default.ini")));
   Console.WriteLine("Created!");
 };
 

--- a/Fushigi/gl/Bfres/Agl/AglLightmap.cs
+++ b/Fushigi/gl/Bfres/Agl/AglLightmap.cs
@@ -42,8 +42,8 @@ namespace Fushigi.gl.Bfres
             Framebuffer = new GLFramebuffer(gl, FramebufferTarget.Framebuffer);
             Framebuffer.SetDrawBuffers(buffers);
 
-            NormalsTexture = new DDSTextureRender(gl, Path.Combine("res", "bfres", "normals.dds"));
-            LUTTexture = new DDSTextureRender(gl, Path.Combine("res", "bfres", "gradient.dds"));
+            NormalsTexture = new DDSTextureRender(gl, Path.Combine(AppContext.BaseDirectory, "res", "bfres", "normals.dds"));
+            LUTTexture = new DDSTextureRender(gl, Path.Combine(AppContext.BaseDirectory, "res", "bfres", "gradient.dds"));
 
             ScreenQuadRender = new ScreenQuad(gl, 1f);
         }
@@ -67,8 +67,8 @@ namespace Fushigi.gl.Bfres
             var size = output.Width / (uint)Math.Pow(2, mip_level);
 
             var shader = GLShaderCache.GetShader(gl, "Lightmap", 
-                Path.Combine("res", "shaders", "Lightmap.vert"),
-                Path.Combine("res", "shaders", "Lightmap.frag"));
+                Path.Combine(AppContext.BaseDirectory, "res", "shaders", "Lightmap.vert"),
+                Path.Combine(AppContext.BaseDirectory, "res", "shaders", "Lightmap.frag"));
 
             shader.Use();
             Framebuffer.Bind();

--- a/Fushigi/gl/Bfres/BfresMaterialRender.cs
+++ b/Fushigi/gl/Bfres/BfresMaterialRender.cs
@@ -31,8 +31,8 @@ namespace Fushigi.gl.Bfres
             Name = material.Name;
 
             Shader = GLShaderCache.GetShader(gl, "Bfres",
-               Path.Combine("res", "shaders", "Bfres.vert"),
-               Path.Combine("res", "shaders", "Bfres.frag"));
+               Path.Combine(AppContext.BaseDirectory, "res", "shaders", "Bfres.vert"),
+               Path.Combine(AppContext.BaseDirectory, "res", "shaders", "Bfres.frag"));
 
             GsysRenderState.Init(material);
             GsysShaderRender.Init(gl, modelRender, meshRender, shape, material);

--- a/Fushigi/gl/Bfres/Gsys/GsysResources.cs
+++ b/Fushigi/gl/Bfres/Gsys/GsysResources.cs
@@ -122,8 +122,8 @@ namespace Fushigi.gl.Bfres
             DiffuseLightmap = GLTextureCube.CreateEmpty(gl, 4);
             SpecularLightmap = GLTextureCube.CreateEmpty(gl, 4);
 
-            CubeMap = new DDSTextureRender(gl, Path.Combine("res", "bfres", "CubemapHDR.dds"), TextureTarget.TextureCubeMapArray);
-         //   DiffuseLightmap = new DDSTextureRender(gl, Path.Combine("res", "bfres", "CubemapLightmap.dds"), TextureTarget.TextureCubeMap);
+            CubeMap = new DDSTextureRender(gl, Path.Combine(AppContext.BaseDirectory, "res", "bfres", "CubemapHDR.dds"), TextureTarget.TextureCubeMapArray);
+         //   DiffuseLightmap = new DDSTextureRender(gl, Path.Combine(AppContext.BaseDirectory, "res", "bfres", "CubemapLightmap.dds"), TextureTarget.TextureCubeMap);
 
             DiffuseLightmap.Bind();
             DiffuseLightmap.WrapS = TextureWrapMode.ClampToEdge;

--- a/Fushigi/gl/HDRScreenBuffer.cs
+++ b/Fushigi/gl/HDRScreenBuffer.cs
@@ -33,8 +33,8 @@ namespace Fushigi.gl
             gl.Viewport(0, 0, Framebuffer.Width, Framebuffer.Height);
 
             var shader = GLShaderCache.GetShader(gl, "PostEffect",
-                Path.Combine("res", "shaders", "screen.vert"),
-                Path.Combine("res", "shaders", "screen.frag"));
+                Path.Combine(AppContext.BaseDirectory, "res", "shaders", "screen.vert"),
+                Path.Combine(AppContext.BaseDirectory, "res", "shaders", "screen.frag"));
 
             shader.Use();
             shader.SetTexture("screenTexture", input, 1);

--- a/Fushigi/gl/Materials/BasicMaterial.cs
+++ b/Fushigi/gl/Materials/BasicMaterial.cs
@@ -18,8 +18,8 @@ namespace Fushigi.gl
         public void Render(GL gl, Matrix4x4 matrix)
         {
             Shader = GLShaderCache.GetShader(gl, "Basic", 
-                Path.Combine("res", "shaders", "Basic.vert"),
-                Path.Combine("res", "shaders", "Basic.frag"));
+                Path.Combine(AppContext.BaseDirectory, "res", "shaders", "Basic.vert"),
+                Path.Combine(AppContext.BaseDirectory, "res", "shaders", "Basic.frag"));
 
             Shader.Use();
             Shader.SetUniform("mtxCam", matrix);

--- a/Fushigi/gl/Primitives/Plane2DRenderer.cs
+++ b/Fushigi/gl/Primitives/Plane2DRenderer.cs
@@ -26,8 +26,8 @@ namespace Fushigi.gl
                 Image = GLTexture2D.Load(_gl, "Wood.png");
 
             var shader = GLShaderCache.GetShader(_gl, "Basic",
-               Path.Combine("res", "shaders", "Basic.vert"),
-               Path.Combine("res", "shaders", "Basic.frag"));
+               Path.Combine(AppContext.BaseDirectory, "res", "shaders", "Basic.vert"),
+               Path.Combine(AppContext.BaseDirectory, "res", "shaders", "Basic.frag"));
 
             shader.Use();
             shader.SetUniform("hasTexture", Image != null ? 1 : 0);

--- a/Fushigi/gl/Textures/GLImageCache.cs
+++ b/Fushigi/gl/Textures/GLImageCache.cs
@@ -25,7 +25,7 @@ namespace Fushigi.gl
         {
             //Default texture
             if (DefaultTexture == null)
-                DefaultTexture = GLTexture2D.Load(gl, Path.Combine("res", "DefaultTexture.png"));
+                DefaultTexture = GLTexture2D.Load(gl, Path.Combine(AppContext.BaseDirectory, "res", "DefaultTexture.png"));
 
             return DefaultTexture;
         }

--- a/Fushigi/param/ParamLoader.cs
+++ b/Fushigi/param/ParamLoader.cs
@@ -15,7 +15,7 @@ namespace Fushigi.param
             mParams = new Dictionary<string, ParamHolder>();
             var nodes = JsonNode.Parse(
                 File.ReadAllText(
-                    Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "res", "AreaParam.json")
+                    Path.Combine(AppContext.BaseDirectory, "res", "AreaParam.json")
                 )
             ).AsObject();
             ParamHolder areaParms = new ParamHolder();

--- a/Fushigi/ui/MainWindow.cs
+++ b/Fushigi/ui/MainWindow.cs
@@ -56,11 +56,11 @@ namespace Fushigi.ui
 
                         {
                             mDefaultFont = io.Fonts.AddFontFromFileTTF(
-                                Path.Combine("res", "Font.ttf"),
+                                Path.Combine(AppContext.BaseDirectory, "res", "Font.ttf"),
                                 size, nativeConfig, io.Fonts.GetGlyphRangesDefault());
 
                              io.Fonts.AddFontFromFileTTF(
-                                Path.Combine("res", "NotoSansCJKjp-Medium.otf"),
+                                Path.Combine(AppContext.BaseDirectory, "res", "NotoSansCJKjp-Medium.otf"),
                                     size, nativeConfigJP, io.Fonts.GetGlyphRangesJapanese());
 
                             //other fonts go here and follow the same schema
@@ -68,15 +68,15 @@ namespace Fushigi.ui
                             try
                             {
                                 io.Fonts.AddFontFromFileTTF(
-                                    Path.Combine("res", "la-regular-400.ttf"),
+                                    Path.Combine(AppContext.BaseDirectory, "res", "la-regular-400.ttf"),
                                     size, iconConfig, rangeHandle.AddrOfPinnedObject());
 
                                 io.Fonts.AddFontFromFileTTF(
-                                    Path.Combine("res", "la-solid-900.ttf"),
+                                    Path.Combine(AppContext.BaseDirectory, "res", "la-solid-900.ttf"),
                                     size, iconConfig, rangeHandle.AddrOfPinnedObject());
 
                                 io.Fonts.AddFontFromFileTTF(
-                                    Path.Combine("res", "la-brands-400.ttf"),
+                                    Path.Combine(AppContext.BaseDirectory, "res", "la-brands-400.ttf"),
                                     size, iconConfig, rangeHandle.AddrOfPinnedObject());
 
                                 io.Fonts.Build();

--- a/Fushigi/util/ActorIconLoader.cs
+++ b/Fushigi/util/ActorIconLoader.cs
@@ -18,8 +18,8 @@ namespace Fushigi.util
 
         public static void Init()
         {
-            string folder = Path.Combine("res", "actor_icons");
-            string actor_icons_zip = Path.Combine("res", "ActorIcons.zip");
+            string folder = Path.Combine(AppContext.BaseDirectory, "res", "actor_icons");
+            string actor_icons_zip = Path.Combine(AppContext.BaseDirectory, "res", "ActorIcons.zip");
             if (!File.Exists(actor_icons_zip))
                 return;
 
@@ -38,7 +38,7 @@ namespace Fushigi.util
 
         public static int GetIcon(GL gl, string gyml, string model)
         {
-            string folder = Path.Combine("res", "actor_icons");
+            string folder = Path.Combine(AppContext.BaseDirectory, "res", "actor_icons");
             string icon_path = Path.Combine(folder, $"{gyml}.bfres_{model}.png");
 
             if (Icons.ContainsKey(icon_path))


### PR DESCRIPTION
I had some issues with the `res` directory not being found correctly when my working directory was somewhere else than the project.

I saw that there was a line in the code which prepended `AppDomain.CurrentDomain.BaseDirectory` before "res"
and there was a line which prepended `AppContext.BaseDirectory`

According to this, there's no difference between them
https://learn.microsoft.com/en-us/dotnet/api/system.appcontext.basedirectory

Sadly I can't really test it out, as I couldn't properly setup my game files...
I'd be happy if someone could test if this works as expected

I still have a bit of cleanup to do