### PR TITLE
Old Code Revamp, Curved Rails, & Actor To Rail Fix

### DIFF
--- a/Fushigi/actor_pack/ActorPack.cs
+++ b/Fushigi/actor_pack/ActorPack.cs
@@ -206,10 +206,9 @@ namespace Fushigi
             }
         }
 
-        private ShapeParamList GetActorShape(SARC.SARC sarc)
+        private ShapeParamList? GetActorShape(SARC.SARC sarc)
         {
-            
-            var file = GetPathGyml(GamePhysicsRef.mPath);
+            var file = GetPathGyml(this.GamePhysicsRef.mPath);
             var dat = sarc.OpenFile(file);
             this.ControllerPath = BymlSerialize.Deserialize<ControllerSetParam>(dat);
             

--- a/Fushigi/course/Course.cs
+++ b/Fushigi/course/Course.cs
@@ -124,7 +124,7 @@ namespace Fushigi.course
 
             foreach (CourseArea area in mAreas)
             {
-                refArr.AddNodeToArray(BymlUtil.CreateNode<string>("", $"Work/Stage/StageParam/{area.GetName()}.game__stage__StageParam.gyml"));
+                refArr.AddNodeToArray(BymlUtil.CreateNode($"Work/Stage/StageParam/{area.GetName()}.game__stage__StageParam.gyml"));
             }
 
             stageParamRoot.AddNode(BymlNodeId.Array, refArr, "RefStages");

--- a/Fushigi/course/CourseRail.cs
+++ b/Fushigi/course/CourseRail.cs
@@ -132,6 +132,7 @@ namespace Fushigi.course
             {
                 this.mHash = RandomUtil.GetRandom();
                 this.mTranslate = new System.Numerics.Vector3();
+                this.mControl = new(this);
             }
 
 

--- a/Fushigi/course/CourseRail.cs
+++ b/Fushigi/course/CourseRail.cs
@@ -211,7 +211,7 @@ namespace Fushigi.course
                 {
                     BymlArrayNode controlNode = new(3);
                     controlNode.AddNodeToArray(BymlUtil.CreateNode(mControl.mTranslate.X));
-                    controlNode.AddNodeToArray(BymlUtil.CreateNode( mControl.mTranslate.Y));
+                    controlNode.AddNodeToArray(BymlUtil.CreateNode(mControl.mTranslate.Y));
                     controlNode.AddNodeToArray(BymlUtil.CreateNode(mControl.mTranslate.Z));
 
                     tbl.AddNode(BymlNodeId.Array, controlNode, "Control1");

--- a/Fushigi/course/CourseRail.cs
+++ b/Fushigi/course/CourseRail.cs
@@ -35,7 +35,16 @@ namespace Fushigi.course
 
             string pointParam = Path.GetFileNameWithoutExtension(BymlUtil.GetNodeData<string>(node["Gyaml"])).Split(".game")[0];
             var railParams = ParamDB.GetRailComponent(pointParam);
+            var railParent = ParamDB.GetRailComponentParent(railParams);
             var comp = ParamDB.GetRailComponentParams(railParams);
+            if (railParent != "null")
+            {
+                var parentComp = ParamDB.GetRailComponentParams(railParent);
+                foreach (var component in parentComp)
+                {
+                    comp.TryAdd(component.Key, component.Value);
+                }
+            }
 
             if (!node.ContainsKey("Dynamic"))
             {

--- a/Fushigi/course/CourseRail.cs
+++ b/Fushigi/course/CourseRail.cs
@@ -210,17 +210,17 @@ namespace Fushigi.course
                 if (mIsCurve)
                 {
                     BymlArrayNode controlNode = new(3);
-                    controlNode.AddNodeToArray(BymlUtil.CreateNode<float>("X", mControl.mTranslate.X));
-                    controlNode.AddNodeToArray(BymlUtil.CreateNode<float>("Y", mControl.mTranslate.Y));
-                    controlNode.AddNodeToArray(BymlUtil.CreateNode<float>("Z", mControl.mTranslate.Z));
+                    controlNode.AddNodeToArray(BymlUtil.CreateNode(mControl.mTranslate.X));
+                    controlNode.AddNodeToArray(BymlUtil.CreateNode( mControl.mTranslate.Y));
+                    controlNode.AddNodeToArray(BymlUtil.CreateNode(mControl.mTranslate.Z));
 
                     tbl.AddNode(BymlNodeId.Array, controlNode, "Control1");
                 }
 
                 BymlArrayNode translateNode = new(3);
-                translateNode.AddNodeToArray(BymlUtil.CreateNode<float>("X", mTranslate.X));
-                translateNode.AddNodeToArray(BymlUtil.CreateNode<float>("Y", mTranslate.Y));
-                translateNode.AddNodeToArray(BymlUtil.CreateNode<float>("Z", mTranslate.Z));
+                translateNode.AddNodeToArray(BymlUtil.CreateNode(mTranslate.X));
+                translateNode.AddNodeToArray(BymlUtil.CreateNode(mTranslate.Y));
+                translateNode.AddNodeToArray(BymlUtil.CreateNode(mTranslate.Z));
 
                 tbl.AddNode(BymlNodeId.Array, translateNode, "Translate");
 

--- a/Fushigi/course/CourseRail.cs
+++ b/Fushigi/course/CourseRail.cs
@@ -132,7 +132,7 @@ namespace Fushigi.course
             {
                 this.mHash = RandomUtil.GetRandom();
                 this.mTranslate = new System.Numerics.Vector3();
-                this.mControl = new(this);
+                this.mControl = new(this, mTranslate);
             }
 
 
@@ -149,7 +149,7 @@ namespace Fushigi.course
             {
                 mHash = BymlUtil.GetNodeData<ulong>(node["Hash"]);
                 mTranslate = BymlUtil.GetVector3FromArray(node["Translate"] as BymlArrayNode);
-                mControl = new(this);
+                mControl = new(this, mTranslate);
 
                 IDictionary<string, ParamDB.ComponentParam> comp;
                 if (ParamDB.TryGetRailPointComponent(pointParam, out var componentName))
@@ -235,7 +235,7 @@ namespace Fushigi.course
         }
         public class CourseRailPointControl
         {
-            public CourseRailPointControl(CourseRail.CourseRailPoint point, System.Numerics.Vector3 pos = default)
+            public CourseRailPointControl(CourseRail.CourseRailPoint point, System.Numerics.Vector3 pos)
             {
                 this.point = point;
                 this.mTranslate = pos;

--- a/Fushigi/course/distance_view/DistantViewManager.cs
+++ b/Fushigi/course/distance_view/DistantViewManager.cs
@@ -12,9 +12,7 @@ namespace Fushigi.course.distance_view
     public class DistantViewManager
     {
         private Dictionary<string, Matrix4x4> LayerMatrices = new Dictionary<string, Matrix4x4>();
-
-        private DVLayerParamTable LvlParamTable = new DVLayerParamTable();
-        public static DVLayerParamTable ParamTable = new DVLayerParamTable();
+        public DVLayerParamTable ParamTable = new DVLayerParamTable();
 
         private CourseActor DVLocator;
 
@@ -29,7 +27,6 @@ namespace Fushigi.course.distance_view
         public void PrepareDVLocator(CourseArea area)
         {
             ParamTable.LoadDefault();
-            LvlParamTable = ParamTable;
 
             foreach (var actor in area.GetActors())
             {
@@ -45,13 +42,13 @@ namespace Fushigi.course.distance_view
                     {
                         string layer_param = (string)DVLocator.mActorParameters["DVLayerParamName"];
                         if (!string.IsNullOrEmpty(layer_param))
-                            LvlParamTable.Load(layer_param);
+                            ParamTable.Load(layer_param);
                     }
                 }
             }
 
             LayerMatrices.Clear();
-            foreach (var layer in this.LvlParamTable.Layers)
+            foreach (var layer in this.ParamTable.Layers)
                 LayerMatrices.Add(layer.Key, Matrix4x4.Identity);
         }
 
@@ -63,7 +60,7 @@ namespace Fushigi.course.distance_view
 
         public void Calc(Vector3 camera_pos)
         {
-            foreach (var layer in this.LvlParamTable.Layers.Keys)
+            foreach (var layer in this.ParamTable.Layers.Keys)
             {
                 var scroll_config = ParamTable.Layers[layer];
                 var locator_pos = DVLocator != null ? DVLocator.mTranslation : Vector3.Zero;

--- a/Fushigi/course/distance_view/DistantViewManager.cs
+++ b/Fushigi/course/distance_view/DistantViewManager.cs
@@ -13,7 +13,8 @@ namespace Fushigi.course.distance_view
     {
         private Dictionary<string, Matrix4x4> LayerMatrices = new Dictionary<string, Matrix4x4>();
 
-        private DVLayerParamTable ParamTable = new DVLayerParamTable();
+        private DVLayerParamTable LvlParamTable = new DVLayerParamTable();
+        public static DVLayerParamTable ParamTable = new DVLayerParamTable();
 
         private CourseActor DVLocator;
 
@@ -28,6 +29,7 @@ namespace Fushigi.course.distance_view
         public void PrepareDVLocator(CourseArea area)
         {
             ParamTable.LoadDefault();
+            LvlParamTable = ParamTable;
 
             foreach (var actor in area.GetActors())
             {
@@ -43,13 +45,13 @@ namespace Fushigi.course.distance_view
                     {
                         string layer_param = (string)DVLocator.mActorParameters["DVLayerParamName"];
                         if (!string.IsNullOrEmpty(layer_param))
-                            ParamTable.Load(layer_param);
+                            LvlParamTable.Load(layer_param);
                     }
                 }
             }
 
             LayerMatrices.Clear();
-            foreach (var layer in this.ParamTable.Layers)
+            foreach (var layer in this.LvlParamTable.Layers)
                 LayerMatrices.Add(layer.Key, Matrix4x4.Identity);
         }
 
@@ -61,7 +63,7 @@ namespace Fushigi.course.distance_view
 
         public void Calc(Vector3 camera_pos)
         {
-            foreach (var layer in this.ParamTable.Layers.Keys)
+            foreach (var layer in this.LvlParamTable.Layers.Keys)
             {
                 var scroll_config = ParamTable.Layers[layer];
                 var locator_pos = DVLocator != null ? DVLocator.mTranslation : Vector3.Zero;

--- a/Fushigi/param/ParamDB.cs
+++ b/Fushigi/param/ParamDB.cs
@@ -114,6 +114,7 @@ namespace Fushigi.param
         public static List<string> GetActorComponents(string actor) => sActors[actor].Components;
 
         public static Dictionary<string, ComponentParam> GetComponentParams(string componentName) => sComponents[componentName].Parameters;
+        public static string GetComponentParent(string componentName) => sComponents[componentName].Parent;
         public static string GetRailComponent(string railName) => sRailParamList[railName].Components[0];
         public static bool TryGetRailPointComponent(string railName, [NotNullWhen(true)] out string? componentName)
         {
@@ -125,6 +126,7 @@ namespace Fushigi.param
             return componentName is not null;
         }
 
+        public static string GetRailComponentParent(string componentName) => sRails[componentName].Parent;
         public static Dictionary<string, ComponentParam> GetRailComponentParams(string componentName) => sRails[componentName].Parameters;
 
         public static string[] GetActors() => sActors.Keys.ToArray();
@@ -207,7 +209,7 @@ namespace Fushigi.param
             {
                 var byml = new Byml.Byml(new MemoryStream(File.ReadAllBytes(railComp)));
                 string name = Path.GetFileNameWithoutExtension(railComp).Split(".engine")[0];
-                Component component = ReadByml(byml);
+                Component component = ReadByml(byml, true);
                 sRails.Add(name, component);
             }
 
@@ -268,7 +270,7 @@ namespace Fushigi.param
             Load(progress);
         }
 
-        static Component ReadByml(Byml.Byml byml)
+        static Component ReadByml(Byml.Byml byml, bool isRailParam = false)
         {
             var root = (BymlHashTable)byml.Root;
 
@@ -340,10 +342,12 @@ namespace Fushigi.param
 
                             /* if the IsInstanceParam value is False, it means that the parameter is not used in a course context
                                 * so, if it is False, we ignore it and move on to the next parameter as we will only read what matters
+
+                                * No, this causes some rail types to save without default parameters. -Donavin
                                 */
                             bool isInstParam = ((BymlNode<bool>)(ht["IsInstanceParam"])).Data;
 
-                            if (!isInstParam)
+                            if (!isInstParam && !isRailParam)
                             {
                                 continue;
                             }

--- a/Fushigi/ui/EditContextBase.cs
+++ b/Fushigi/ui/EditContextBase.cs
@@ -36,7 +36,7 @@ namespace Fushigi.ui
 
         public ICommittable BeginBatchAction()
         {
-            mCurrentActionBatch = [];
+            mCurrentActionBatch ??= [];
             var batchAction = new BatchAction(this);
             mNestedBatchActions.Push(batchAction);
             return batchAction;

--- a/Fushigi/ui/widgets/CourseScene.cs
+++ b/Fushigi/ui/widgets/CourseScene.cs
@@ -581,7 +581,7 @@ namespace Fushigi.ui.widgets
                         ImGui.TextDisabled("Invalid");
                     }
                     ImGui.TableNextColumn();
-                    if (railIndex >= 0)
+                    if (railIndex >= 0 && rails[railIndex].mPoints.Count > 0)
                     {
                         int pointIndex = rails[railIndex].mPoints.FindIndex(x => x.mHash == link.mDestPoint);
 

--- a/Fushigi/ui/widgets/CourseScene.cs
+++ b/Fushigi/ui/widgets/CourseScene.cs
@@ -105,7 +105,7 @@ namespace Fushigi.ui.widgets
             "DvFar9",
             "DvFar10"
         ];
-        public static Regex RxLetters = new(@"\d+");
+        public static Regex NumberRegex = new(@"\d+");
 
         // This code sorts the layer order on the layer panel.
         // You can look through it before deciding if it's optimized enough to include.
@@ -125,8 +125,8 @@ namespace Fushigi.ui.widgets
         // {
         //     public int Compare(string x, string y)
         //     {
-        //         var idX = layerSortTypes.IndexOf(RxLetters.Replace(x, ""));
-        //         var idY = layerSortTypes.IndexOf(RxLetters.Replace(y, ""));
+        //         var idX = layerSortTypes.IndexOf(NumberRegex.Replace(x, ""));
+        //         var idY = layerSortTypes.IndexOf(NumberRegex.Replace(y, ""));
         //         if(idX != -1)
         //         {
         //                 int result = idY == -1 ? 1:idX.CompareTo(idY);
@@ -2748,8 +2748,11 @@ namespace Fushigi.ui.widgets
                 {
                     for (var i = 0; i < fileteredLayers.Count; i++)
                     {
-                        layerCount = mLayersVisibility.Count(x => RxLetters.Replace(x.Key, "") == fileteredLayers[i]);
-                        var layer = i < 2 ? $"{fileteredLayers[i]} ({layerCount}/{MaxLayerCount})" : fileteredLayers[i];
+                        var layer = fileteredLayers[i];
+                        layerCount = mLayersVisibility.Keys
+                            .Count(x => x.StartsWith(layer) && NumberRegex.IsMatch(x.AsSpan(layer.Length..)));
+                        if (layer == "PlayArea" || layer == "DecoArea")
+                            layer += $" ({layerCount}/{MaxLayerCount})";
 
                         ImGui.BeginDisabled(layerCount == MaxLayerCount);
 

--- a/Fushigi/ui/widgets/CourseScene.cs
+++ b/Fushigi/ui/widgets/CourseScene.cs
@@ -16,6 +16,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Fushigi.rstb;
+using Fushigi.course.distance_view;
 using Fushigi.ui.helpers;
 using Fasterflect;
 
@@ -46,7 +47,7 @@ namespace Fushigi.ui.widgets
 
         string mActorSearchText = "";
 
-        CourseLink? mSelectedGlobalLink = null;
+        //CourseLink? mSelectedGlobalLink = null;
 
         string[] viewMode = [
             "View All Actors", 
@@ -195,6 +196,7 @@ namespace Fushigi.ui.widgets
             RailsPanel();
 
             GlobalLinksPanel();
+
             RailLinksPanel();
 
             LocalLinksPanel();
@@ -457,6 +459,13 @@ namespace Fushigi.ui.widgets
                         ctx, "Delete actors");
             }
 
+            ImGui.SameLine();
+
+            if (ImGui.Button("Add Layer"))
+            {
+                _ = AddLayerWithLayerWindow();
+            }
+
             ImGui.AlignTextToFramePadding();
             ImGui.Text(IconUtil.ICON_SEARCH.ToString());
             ImGui.SameLine();
@@ -537,24 +546,25 @@ namespace Fushigi.ui.widgets
 
                 for (int i = 0; i < railLinks.Count; i++)
                 {
+                    ImGui.PushID(i);
                     ImGui.TableNextRow();
                     ImGui.TableSetColumnIndex(0);
-                    ImGui.PushID(i);
                     CourseActorToRailLink link = railLinks[i];
 
                     string hash = link.mSourceActor.ToString();
                     int actorIndex = actors.FindIndex(x => x.mHash == link.mSourceActor);
+                    ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
                     if (ImGui.InputText("##actor", ref hash, 100) &&
                         ulong.TryParse(hash, out ulong hashInt))
-                        link.mSourceActor = hashInt;
+                            link.mSourceActor = hashInt;
                     if(actorIndex == -1)
                     {
                         ImGui.SameLine();
                         ImGui.TextDisabled("Invalid");
                     }
-
                     ImGui.TableNextColumn();
                     int railIndex = rails.FindIndex(x => x.mHash == link.mDestRail);
+                    ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
                     if (ImGui.BeginCombo("##rail", railIndex >= 0 ? ("rail " + railIndex) : "None"))
                     {
                         for (int iRail = 0; iRail < rails.Count; iRail++)
@@ -577,6 +587,7 @@ namespace Fushigi.ui.widgets
                         if (pointIndex == -1)
                             pointIndex = 0;
 
+                        ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
                         if (ImGui.InputInt("##railpoint", ref pointIndex))
                             pointIndex = Math.Clamp(pointIndex, 0, rails[railIndex].mPoints.Count - 1);
 
@@ -584,7 +595,7 @@ namespace Fushigi.ui.widgets
                     }
 
                     ImGui.TableNextColumn();
-                    if (ImGui.Button("Delete", new Vector2(ImGui.GetContentRegionAvail().X * 0.65f, 0)))
+                    if (ImGui.Button("Delete", new Vector2(ImGui.GetContentRegionAvail().X  - ImGui.GetStyle().ScrollbarSize, 0)))
                     {
                         ctx.DeleteRailLink(link);
                         i--;
@@ -646,8 +657,7 @@ namespace Fushigi.ui.widgets
                         }
                         ImGui.PopItemWidth();
 
-                    ImGui.TableNextRow();
-                    ImGui.TableSetColumnIndex(0);
+                    ImGui.TableNextColumn();
                         ImGui.Text("Actor Hash");
                         ImGui.TableNextColumn();
                         string hash = mSelectedActor.mHash.ToString();
@@ -655,13 +665,12 @@ namespace Fushigi.ui.widgets
                         ImGui.InputText("##Actor Hash", ref hash, 256, ImGuiInputTextFlags.ReadOnly);
                         ImGui.PopItemWidth();
 
-                    ImGui.TableNextRow();
-                    ImGui.TableSetColumnIndex(0);
-
+                    ImGui.TableNextColumn();
+                        ImGui.Separator();
+                    ImGui.TableNextColumn();
                         ImGui.Separator();
 
-                    ImGui.TableNextRow();
-                    ImGui.TableSetColumnIndex(0);
+                    ImGui.TableNextColumn();
                         ImGui.AlignTextToFramePadding();
                         ImGui.Text("Name");
 
@@ -674,10 +683,10 @@ namespace Fushigi.ui.widgets
 
                         ImGui.PopItemWidth();
                     
-                    ImGui.TableNextRow();
-                    ImGui.TableSetColumnIndex(0);
+                    ImGui.TableNextColumn();
                         ImGui.Text("Layer");
                         ImGui.TableNextColumn();
+                        ImGui.PushItemWidth(ImGui.GetColumnWidth() - ImGui.GetStyle().ScrollbarSize);
 
                         if (ImGui.BeginCombo("##Dropdown", mSelectedActor.mLayer))
                         {
@@ -753,10 +762,10 @@ namespace Fushigi.ui.widgets
 
                     if (ImGui.BeginTable("##Links", 3, ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.Resizable))
                     {
+                        ImGui.TableNextRow();
+                            ImGui.TableSetColumnIndex(0);
                         for (int i = 0; i < hashArray.Count; i++)
                         {
-                            ImGui.TableNextRow();
-                            ImGui.TableSetColumnIndex(0);
                             ImGui.PushID($"{hashArray[i].ToString()}_{i}");
                             ImGui.SetCursorPosX(ImGui.GetCursorPosX() + ImGui.GetStyle().FramePadding.X);
                             ImGui.Text("Destination");
@@ -842,6 +851,7 @@ namespace Fushigi.ui.widgets
                                 editContext.DeleteLink(linkName, mSelectedActor.mHash, hashArray[i]);
 
                             ImGui.PopID();
+                            ImGui.TableNextColumn();
                         }
                         ImGui.EndTable();
                     }
@@ -889,8 +899,7 @@ namespace Fushigi.ui.widgets
                             ImGui.Combo("##mModelType", ref Unsafe.As<CourseUnit.ModelType, int>(ref mSelectedUnit.mModelType),
                                 CourseUnit.ModelTypeNames, CourseUnit.ModelTypeNames.Length);
 
-                        ImGui.TableNextRow();
-                            ImGui.TableSetColumnIndex(0);
+                        ImGui.TableNextColumn();
 
                             ImGui.Text("Skin Division"); ImGui.TableNextColumn();
                             ImGui.Combo("##SkinDivision", ref Unsafe.As<CourseUnit.SkinDivision, int>(ref mSelectedUnit.mSkinDivision),
@@ -1001,8 +1010,7 @@ namespace Fushigi.ui.widgets
                             if (ImGui.Checkbox("##IsClosed", ref mSelectedUnitRail.IsClosed))
                                 mSelectedUnitRail.mCourseUnit.GenerateTileSubUnits();
 
-                        ImGui.TableNextRow();
-                            ImGui.TableSetColumnIndex(0);
+                        ImGui.TableNextColumn();
                             //Depth editing for bg unit. All points share the same depth, so batch edit the Z point
                             float depth = mSelectedUnitRail.Points.Count == 0 ? 0 : mSelectedUnitRail.Points[0].Position.Z;
 
@@ -1019,7 +1027,7 @@ namespace Fushigi.ui.widgets
                     }
                 }
             }
-            else if (mSelectedGlobalLink != null)
+            else if (editContext.IsSingleObjectSelected(out CourseLink? mSelectedGlobalLink))
             {
                 ImGui.AlignTextToFramePadding();
                 ImGui.Text($"Selected Global Link");
@@ -1047,8 +1055,7 @@ namespace Fushigi.ui.widgets
                                 mSelectedGlobalLink.mSource = Convert.ToUInt64(srcHash);
                             }
 
-                        ImGui.TableNextRow();
-                            ImGui.TableSetColumnIndex(0);
+                        ImGui.TableNextColumn();
                             ImGui.Text("Destination Hash"); ImGui.TableNextColumn();
                             string destHash = mSelectedGlobalLink.mDest.ToString();
                             if (ImGui.InputText("##Dest Hash", ref destHash, 256, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.EnterReturnsTrue))
@@ -1056,8 +1063,7 @@ namespace Fushigi.ui.widgets
                                 mSelectedGlobalLink.mDest = Convert.ToUInt64(destHash);
                             }
 
-                        ImGui.TableNextRow();
-                            ImGui.TableSetColumnIndex(0);
+                        ImGui.TableNextColumn();
                             ImGui.Text("Link Type"); ImGui.TableNextColumn();
 
                             List<string> types = linkTypes.ToList();
@@ -1092,8 +1098,7 @@ namespace Fushigi.ui.widgets
                                 mSelectedRail.mHash = Convert.ToUInt64(hash);
                             }
 
-                        ImGui.TableNextRow();
-                        ImGui.TableSetColumnIndex(0);
+                        ImGui.TableNextColumn();
                             ImGui.Text("IsClosed");
                             ImGui.TableNextColumn();
                             ImGui.Checkbox("##IsClosed", ref mSelectedRail.mIsClosed);
@@ -1106,10 +1111,10 @@ namespace Fushigi.ui.widgets
                 {
                     if (ImGui.BeginTable("DynamProps", 2, ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.Resizable))
                     {
+                        ImGui.TableNextRow();
+                        ImGui.TableSetColumnIndex(0);
                         foreach (KeyValuePair<string, object> param in mSelectedRail.mParameters)
                         {
-                            ImGui.TableNextRow();
-                            ImGui.TableSetColumnIndex(0);
                             string type = param.Value.GetType().ToString();
                             ImGui.Text(param.Key);
                             ImGui.TableNextColumn();
@@ -1131,6 +1136,7 @@ namespace Fushigi.ui.widgets
                                     }
                                     break;
                             }
+                            ImGui.TableNextColumn();
                         }
                         ImGui.EndTable();
                     }
@@ -1159,8 +1165,7 @@ namespace Fushigi.ui.widgets
                                 mSelectedRailPoint.mHash = Convert.ToUInt64(hash);
                             }
 
-                        ImGui.TableNextRow();
-                        ImGui.TableSetColumnIndex(0);
+                        ImGui.TableNextColumn();
                             ImGui.AlignTextToFramePadding();
                             ImGui.Text("Translation");
                             
@@ -1168,8 +1173,7 @@ namespace Fushigi.ui.widgets
 
                             ImGui.DragFloat3("##Translation", ref mSelectedRailPoint.mTranslate, 0.25f);
 
-                        ImGui.TableNextRow();
-                        ImGui.TableSetColumnIndex(0);
+                        ImGui.TableNextColumn();
                             ImGui.AlignTextToFramePadding();
                             ImGui.Text("Curve Control");
                             
@@ -1193,10 +1197,10 @@ namespace Fushigi.ui.widgets
                 {
                     if (ImGui.BeginTable("DynamProps", 2, ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.Resizable))
                     {
+                        ImGui.TableNextRow();
+                            ImGui.TableSetColumnIndex(0);
                         foreach (KeyValuePair<string, object> param in mSelectedRailPoint.mParameters)
                         {
-                            ImGui.TableNextRow();
-                            ImGui.TableSetColumnIndex(0);
                             string type = param.Value.GetType().ToString();
                             ImGui.Text(param.Key);
                             ImGui.TableNextColumn();
@@ -1232,6 +1236,7 @@ namespace Fushigi.ui.widgets
                                     }
                                     break;
                             }
+                            ImGui.TableNextColumn();
                         }
                         ImGui.EndTable();
                     }
@@ -1275,10 +1280,11 @@ namespace Fushigi.ui.widgets
 
                 if (ImGui.BeginTable("AreaParms", 2, ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.Resizable))
                 {
+                    ImGui.TableNextRow();
+                    ImGui.TableSetColumnIndex(0);
                     foreach (string key in areaParams.Keys)
                     {
-                        ImGui.TableNextRow();
-                        ImGui.TableSetColumnIndex(0);
+                        
                         string paramType = areaParams[key];
 
                         //if (!area.ContainsParam(key))
@@ -1338,6 +1344,7 @@ namespace Fushigi.ui.widgets
                                 break;
                         }
                         ImGui.PopItemWidth();
+                        ImGui.TableNextColumn();
                     }
                     ImGui.EndTable();
                 }
@@ -1426,7 +1433,7 @@ namespace Fushigi.ui.widgets
 
                                 void SelectRail()
                                 {
-                                    editContext.DeselectAllOfType<BGUnitRail>();
+                                    editContext.DeselectAll();
                                     editContext.Select(rail);
                                 }
 
@@ -1571,7 +1578,7 @@ namespace Fushigi.ui.widgets
 
             foreach (CourseRail rail in railHolder.mRails)
             {
-                var rail_node_flags = ImGuiTreeNodeFlags.None;
+                var rail_node_flags = ImGuiTreeNodeFlags.OpenOnArrow;
                 if (editContext.IsSelected(rail) &&
                     !editContext.IsAnySelected<CourseRail.CourseRailPoint>())
                 {
@@ -1610,18 +1617,20 @@ namespace Fushigi.ui.widgets
 
         private void CourseGlobalLinksView(CourseLinkHolder linkHolder)
         {
+            var editContext = areaScenes[selectedArea].EditContext;
             for (int i = 0; i < linkHolder.mLinks.Count; i++)
             {
                 CourseLink link = linkHolder.mLinks[i];
-                if (ImGui.Selectable($"Link {i}"))
+                if (ImGui.Selectable($"Link {i}", editContext.IsSelected(link)))
                 {
-                    mSelectedGlobalLink = link;
+                    editContext.DeselectAll();
+                    editContext.Select(link);
                 }
             }
         }
         
         //VERY ROUGH BASE
-        //Still need to implement recursion on getting links, currently just displays the top most links
+        //TODO, optomize recursion
         private void AreaLocalLinksView(CourseArea area)
         {
             var links = area.mLinkHolder;
@@ -1633,8 +1642,11 @@ namespace Fushigi.ui.widgets
 
             var topLinks = area.GetActors()
                 .Where(x => links.GetDestHashesFromSrc(x.mHash).Count > 0);
-
-            RecursiveLinkFind(area, links, editContext, em, topLinks);
+            if (ImGui.BeginTable("##Links", 2, ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.Resizable))
+            {
+                RecursiveLinkFind(area, links, editContext, em, topLinks);
+                ImGui.EndTable();
+            }
 
             ImGui.PopClipRect();
 
@@ -1646,92 +1658,68 @@ namespace Fushigi.ui.widgets
         {
             foreach (CourseActor actor in linkList)
             {
+                ImGui.TableNextRow();
+                
                 ImGuiTreeNodeFlags node_flags = ImGuiTreeNodeFlags.FramePadding | ImGuiTreeNodeFlags.OpenOnArrow;
                 ImGui.PushID($"##{actor.mHash}");
+
+                string actorName = actor.mPackName;
+                string name = actor.mName;
+                ulong actorHash = actor.mHash;
+                bool isSelected = editContext.IsSelected(actor);
+
+                ImGui.TableSetColumnIndex(1);
+                ImGui.BeginDisabled();
+                ImGui.Text(name);
+                ImGui.EndDisabled();
+
                 bool expanded = false;
                 bool isVisible = true;
                 float margin = 1.5f * em;
                 float headerHeight = 1.4f * em;
                 Vector2 cp = ImGui.GetCursorScreenPos();
+                ImGui.TableSetColumnIndex(0);
+
                 if(links.GetDestHashesFromSrc(actor.mHash).Count > 0)
                 {
+                    if (isSelected)
+                        node_flags |= ImGuiTreeNodeFlags.Selected;
                     expanded = ImGui.TreeNodeEx($"{actor.mHash}", node_flags, actor.mPackName);
-
-                    if (ImGui.IsItemFocused())
-                    {
-                        activeViewport.SelectedActor(actor);
-                    }
-
-                    if (ImGui.IsItemHovered() && ImGui.IsMouseDoubleClicked(0))
-                    {
-                        activeViewport.FrameSelectedActor(actor);
-                    }
-
-                    if (!isVisible)
-                        ImGui.BeginDisabled();
-
-                    UpdateWonderVisibility(actor, links, area);
-
-                    if (expanded)
-                    {
-                        foreach (var link in links.GetDestHashesFromSrc(actor.mHash))
-                        {
-                            ImGui.PushID($"##{link.Key}");
-                            if(ImGui.TreeNodeEx($"##{link.Key}", ImGuiTreeNodeFlags.FramePadding, link.Key))
-                            {
-                                var reLinks = area.GetActors().Where(x => link.Value.Contains(x.mHash));
-                                RecursiveLinkFind(area, links, editContext, em, reLinks);
-                                ImGui.TreePop();
-                            }
-                            ImGui.PopID();
-                        }
-                        ImGui.TreePop();
-                    }
                 }
                 else
                 {
-                    string actorName = actor.mPackName;
-                    string name = actor.mName;
-                    ulong actorHash = actor.mHash;
-                    //Check if the node is within the necessary search filter requirements if search is used
-                    bool HasText = actor.mName.IndexOf(mActorSearchText, StringComparison.OrdinalIgnoreCase) >= 0 ||
-                                actor.mPackName.IndexOf(mActorSearchText, StringComparison.OrdinalIgnoreCase) >= 0 ||
-                                actor.ToString().Equals(mActorSearchText);
+                    expanded = ImGui.Selectable(actorName, isSelected, ImGuiSelectableFlags.SpanAllColumns);
+                }
 
-                    if (!HasText)
-                        continue;
+                if (ImGui.IsItemFocused())
+                {
+                    activeViewport.SelectedActor(actor);
+                }
 
-                    bool isSelected = editContext.IsSelected(actor);
+                if (ImGui.IsItemHovered() && ImGui.IsMouseDoubleClicked(0))
+                {
+                    activeViewport.FrameSelectedActor(actor);
+                }
 
-                    ImGui.PushID($"##{actorName}");
-                    if (ImGui.BeginTable("##Links", 2, ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.Resizable))
+                if (!isVisible)
+                    ImGui.BeginDisabled();
+
+                UpdateWonderVisibility(actor, links, area);
+
+                if (expanded && (links.GetDestHashesFromSrc(actor.mHash).Count > 0))
+                {
+                    foreach (var link in links.GetDestHashesFromSrc(actor.mHash))
                     {
-                        ImGui.TableNextRow();
-                            ImGui.TableSetColumnIndex(0);
-                    
-                        if (ImGui.Selectable(actorName, isSelected, ImGuiSelectableFlags.SpanAllColumns))
+                        ImGui.PushID($"##{link.Key}");
+                        if(ImGui.TreeNodeEx($"##{link.Key}", ImGuiTreeNodeFlags.FramePadding, link.Key))
                         {
-                            activeViewport.SelectedActor(actor);
+                            var reLinks = area.GetActors().Where(x => link.Value.Contains(x.mHash));
+                            RecursiveLinkFind(area, links, editContext, em, reLinks);
+                            ImGui.TreePop();
                         }
-                        else if (ImGui.IsItemFocused())
-                        {
-                            activeViewport.SelectedActor(actor);
-                        }
-
-                        if (ImGui.IsItemHovered() && ImGui.IsMouseDoubleClicked(0))
-                        {
-                            activeViewport.FrameSelectedActor(actor);
-                        }
-
-
-                        ImGui.TableNextColumn();
-                        ImGui.BeginDisabled();
-                        ImGui.Text(name);
-                        ImGui.EndDisabled();
-                        ImGui.EndTable();
+                        ImGui.PopID();
                     }
-
-                    ImGui.PopID();
+                    ImGui.TreePop();
                 }
             
                 if (!isVisible)
@@ -2173,13 +2161,11 @@ namespace Fushigi.ui.widgets
                         ImGui.DragFloat3("##Scale", ref actor.mScale, 0.25f, 0, float.MaxValue);
                         ImGui.PopItemWidth();
 
-                    ImGui.TableNextRow();
-                        ImGui.TableSetColumnIndex(0);
+                    ImGui.TableNextColumn();
 
                         EditFloat3RadAsDeg("Rotation", ref actor.mRotation, 0.25f);
 
-                    ImGui.TableNextRow();
-                        ImGui.TableSetColumnIndex(0);
+                    ImGui.TableNextColumn();
 
                         ImGui.AlignTextToFramePadding();
                         ImGui.Text("Translation");
@@ -2220,10 +2206,11 @@ namespace Fushigi.ui.widgets
 
                     if (ImGui.BeginTable("DynamProps", 2, ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.Resizable))
                     {
+                        ImGui.TableNextRow();
+                            ImGui.TableSetColumnIndex(0);
+
                         if (param == "ChildActorSelectName" && ChildActorParam.ActorHasChildParam(actor.mPackName))
                         {
-                            ImGui.TableNextRow();
-                            ImGui.TableSetColumnIndex(0);
                             string id = $"##{param}";
                             List<string> list = ChildActorParam.GetActorParams(actor.mPackName);
                             int selected = list.IndexOf(actor.mActorParameters["ChildActorSelectName"].ToString());
@@ -2235,13 +2222,12 @@ namespace Fushigi.ui.widgets
                             {
                                 actor.mActorParameters["ChildActorSelectName"] = list[selected];
                             }
+                            ImGui.PopItemWidth();
                         }
                         else
                         {
                             foreach (KeyValuePair<string, ParamDB.ComponentParam> pair in ParamDB.GetComponentParams(param))
                             {
-                                ImGui.TableNextRow();
-                                ImGui.TableSetColumnIndex(0);
                                 string id = $"##{pair.Key}";
 
                                 ImGui.AlignTextToFramePadding();
@@ -2307,6 +2293,7 @@ namespace Fushigi.ui.widgets
                                 }
 
                                 ImGui.PopItemWidth();
+                                ImGui.TableNextColumn();
                             }
                         }
 
@@ -2335,6 +2322,8 @@ namespace Fushigi.ui.widgets
             CourseAreaEditContext ctx, string actionName)
         {
             var actors = objectsToDelete.OfType<CourseActor>();
+            if (actors.Count() == 1)
+                actionName = "Delete "+actors.ElementAt(0).mPackName;
             List<string> dstMsgStrs = [];
             List<string> srcMsgStrs = [];
 
@@ -2446,33 +2435,79 @@ namespace Fushigi.ui.widgets
             } while ((modifier & KeyboardModifier.Shift) > 0);
         }
 
+        private async Task AddLayerWithLayerWindow()
+        {
+            var viewport = activeViewport;
+            var area = selectedArea;
+            var ctx = areaScenes[selectedArea].EditContext;
 
+            if(mOpenToolWindows.Any(x=>x is SelectActorAndLayerWindow))
+                return;
+
+            var window = new SelectActorAndLayerWindow(mLayersVisibility, false);
+            mOpenToolWindows.Add(window);
+
+            var result = await window.Result();
+            if (!result.TryGetValue(out var resultVal))
+                return;
+
+            var layer = result.Value.layer;
+
+            if(layer == "PlayArea" || layer == "DecoArea")
+            {
+                var i = layer == "DecoArea" ? 0:1;
+                do
+                {
+                    i++;
+                } while (mLayersVisibility.Keys.Any(x => x == $"{layer}{i}"));
+                layer += i;
+            }
+
+            mLayersVisibility[layer] = true;
+        }
 
         interface IToolWindow
         {
             void Draw(ref bool windowOpen);
         }
 
-        class SelectActorAndLayerWindow(IReadOnlyDictionary<string, bool> mLayersVisibility) : IToolWindow
+        class SelectActorAndLayerWindow(IReadOnlyDictionary<string, bool> mLayersVisibility, bool addActors = true) : IToolWindow
         {
             public void Draw(ref bool windowOpen)
             {
                 bool status;
-                if (mSelectedActor == null)
+                if(addActors)
                 {
-                    status = ImGui.Begin("Add Actor###SelectActorLayer", ref windowOpen);
-                    SelectActorToAdd();
-                }
-                else if(mSelectedLayer == null)
-                {
-                    status = ImGui.Begin("Select Layer###SelectActorLayer", ref windowOpen);
-                    SelectActorToAddLayer();
+                    if (mSelectedActor == null)
+                    {
+                        status = ImGui.Begin("Add Actor###SelectActorLayer", ref windowOpen);
+                        SelectActorToAdd();
+                    }
+                    else if(mSelectedLayer == null)
+                    {
+                        status = ImGui.Begin("Select Layer###SelectActorLayer", ref windowOpen);
+                        SelectActorToAddLayer();
+                    }
+                    else
+                    {
+                        mPromise.TrySetResult((addActors ? mSelectedActor:"", mSelectedLayer));
+                        windowOpen = false;
+                        return;
+                    }
                 }
                 else
                 {
-                    mPromise.TrySetResult((mSelectedActor, mSelectedLayer));
-                    windowOpen = false;
-                    return;
+                    if(mSelectedLayer == null)
+                    {
+                        status = ImGui.Begin("Select Layer###SelectActorLayer", ref windowOpen);
+                        SelectLayerToAdd();
+                    }
+                    else
+                    {
+                        mPromise.TrySetResult(("", mSelectedLayer));
+                        windowOpen = false;
+                        return;
+                    }
                 }
 
                 if (ImGui.IsKeyDown(ImGuiKey.Escape))
@@ -2525,10 +2560,43 @@ namespace Fushigi.ui.widgets
                 ImGui.InputText("Search", ref mAddLayerSearchQuery, 256);
 
                 var fileteredLayers = mLayersVisibility.Keys.ToArray().ToImmutableList();
-
+                
                 if (mAddLayerSearchQuery != "")
                 {
                     fileteredLayers = FuzzySharp.Process.ExtractAll(mAddLayerSearchQuery, mLayersVisibility.Keys.ToArray(), cutoff: 65)
+                        .OrderByDescending(result => result.Score)
+                        .Select(result => result.Value)
+                        .ToImmutableList();
+                }
+
+                if (ImGui.BeginListBox("Select the layer you want to add the actor to.", ImGui.GetContentRegionAvail()))
+                {
+                    foreach (string layer in fileteredLayers)
+                    {
+                        ImGui.Selectable(layer);
+
+                        if (ImGui.IsItemHovered() && ImGui.IsMouseDoubleClicked(0))
+                            mSelectedLayer = layer;
+                    }
+
+                    ImGui.EndListBox();
+                }
+            }
+
+            // TODO, maybe find a way to combine with SelectActorToAddLayer(), if that's needed
+            private void SelectLayerToAdd()
+            {
+                ImGui.InputText("Search", ref mAddLayerSearchQuery, 256);
+
+                string[] Layers = ["PlayArea", "DecoArea", "DecoAreaFront"];
+                Layers = Layers.Concat(DistantViewManager.ParamTable.Layers.Keys)
+                    .Except(mLayersVisibility.Keys)
+                    .ToArray();
+                var fileteredLayers = Layers.ToImmutableList();
+                
+                if (mAddLayerSearchQuery != "")
+                {
+                    fileteredLayers = FuzzySharp.Process.ExtractAll(mAddLayerSearchQuery, Layers, cutoff: 65)
                         .OrderByDescending(result => result.Score)
                         .Select(result => result.Value)
                         .ToImmutableList();

--- a/Fushigi/ui/widgets/LevelViewport.cs
+++ b/Fushigi/ui/widgets/LevelViewport.cs
@@ -362,6 +362,8 @@ namespace Fushigi.ui.widgets
             //Display skybox
             EnvironmentData.RenderSky(gl, this.Camera);
 
+            // Actors are listed in the order they were pulled from the yaml.
+            // So they are ordered by depth for rendering.
             foreach (var actor in this.mArea.GetActors().OrderBy(x => x.mTranslation.Z))
             {
                 actor.wonderVisible = WonderViewMode == actor.mWonderView || 

--- a/Fushigi/ui/widgets/LevelViewport.cs
+++ b/Fushigi/ui/widgets/LevelViewport.cs
@@ -880,7 +880,6 @@ namespace Fushigi.ui.widgets
                     }
                 }
 
-
                 dragRelease = false;
             }
 
@@ -1008,6 +1007,11 @@ namespace Fushigi.ui.widgets
                     bool isSelected = mEditContext.IsSelected(rail);
                     bool hovered = MathUtil.HitTestLineLoopPoint(GetPoints(), 10f, ImGui.GetMousePos());
 
+                    //Rail selection disabled for now as it conflicts with point selection
+                    //Putting it at the top of the for loop should make it prioritize points -Donavin
+                    if (hovered)
+                      newHoveredObject = rail;
+
                     CourseRail.CourseRailPoint selectedPoint = null;
 
                     foreach (var point in rail.mPoints)
@@ -1036,9 +1040,11 @@ namespace Fushigi.ui.widgets
                     if (selectedPoint != null && ImGui.IsMouseReleased(0))
                     {
                         //Check if point matches an existing point, remove if intersected
-                        var matching = rail.mPoints.Where(x => x.mTranslate == selectedPoint.mTranslate).ToList();
-                        if (matching.Count > 1)
-                            rail.mPoints.Remove(selectedPoint);
+                        //The base game has overlapping points, this breaks things
+
+                        // var matching = rail.mPoints.Where(x => x.mTranslate == selectedPoint.mTranslate).ToList();
+                        // if (matching.Count > 1)
+                        //     rail.mPoints.Remove(selectedPoint);
                     }
                 
                     bool add_point = ImGui.IsMouseClicked(0) && ImGui.IsMouseDown(0) && ImGui.GetIO().KeyAlt;
@@ -1080,10 +1086,6 @@ namespace Fushigi.ui.widgets
                         this.mEditContext.Select(newPoint);
                         newHoveredObject = newPoint;
                     }
-
-                    //Rail selection disabled for now as it conflicts with point selection
-                    // if (hovered)
-                    //   newHoveredObject = rail;
                 }
 
                 foreach (CourseRail rail in mArea.mRailHolder.mRails)

--- a/Fushigi/ui/widgets/LevelViewport.cs
+++ b/Fushigi/ui/widgets/LevelViewport.cs
@@ -1008,9 +1008,10 @@ namespace Fushigi.ui.widgets
                     bool hovered = MathUtil.HitTestLineLoopPoint(GetPoints(), 10f, ImGui.GetMousePos());
 
                     //Rail selection disabled for now as it conflicts with point selection
-                    //Putting it at the top of the for loop should make it prioritize points -Donavin
-                    if (hovered)
-                      newHoveredObject = rail;
+                    //Putting it at the top of the for loop should make it prioritize points 
+                    //TODO curved rails still need work-Donavin
+                    // if (hovered)
+                    //   newHoveredObject = rail;
 
                     CourseRail.CourseRailPoint selectedPoint = null;
 

--- a/Fushigi/ui/widgets/LevelViewport.cs
+++ b/Fushigi/ui/widgets/LevelViewport.cs
@@ -362,7 +362,7 @@ namespace Fushigi.ui.widgets
             //Display skybox
             EnvironmentData.RenderSky(gl, this.Camera);
 
-            foreach (var actor in this.mArea.GetActors())
+            foreach (var actor in this.mArea.GetActors().OrderBy(x => x.mTranslation.Z))
             {
                 actor.wonderVisible = WonderViewMode == actor.mWonderView || 
                                         WonderViewMode == WonderViewType.Normal ||

--- a/Fushigi/ui/widgets/LevelViewport.cs
+++ b/Fushigi/ui/widgets/LevelViewport.cs
@@ -82,6 +82,7 @@ namespace Fushigi.ui.widgets
 
         public bool IsViewportHovered;
         public bool IsViewportActive;
+        public bool isPanGesture;
         public WonderViewType WonderViewMode = WonderViewType.Normal;
         public bool PlayAnimations = false;
         public bool ShowGrid = true;
@@ -219,8 +220,9 @@ namespace Fushigi.ui.widgets
 
         public void HandleCameraControls(double deltaSeconds)
         {
-            bool isPanGesture = ImGui.IsMouseDragging(ImGuiMouseButton.Middle) ||
-                (ImGui.IsMouseDragging(ImGuiMouseButton.Left) && ImGui.GetIO().KeyShift && !mEditContext.IsAnySelected<CourseActor>());
+            isPanGesture = ImGui.IsMouseDragging(ImGuiMouseButton.Middle) ||
+                (ImGui.IsMouseDragging(ImGuiMouseButton.Left) && ImGui.GetIO().KeyShift && 
+                mHoveredObject == null && !mEditContext.IsSelected(mHoveredObject) && !dragRelease);
 
             if (IsViewportActive && isPanGesture)
             {
@@ -751,7 +753,7 @@ namespace Fushigi.ui.widgets
                 return;
             }
           
-            if (ImGui.IsMouseDragging(ImGuiMouseButton.Left))
+            if (ImGui.IsMouseDragging(ImGuiMouseButton.Left) && !isPanGesture)
             {
                 if (mEditContext.IsAnySelected<CourseActor>())
                 {
@@ -789,6 +791,22 @@ namespace Fushigi.ui.widgets
                         rail.mTranslate = posVec;
                     }
                 }
+                if (mEditContext.IsSingleObjectSelected(out CourseRail.CourseRailPointControl? railCont))
+                {
+                    Vector3 posVec = ScreenToWorld(ImGui.GetMousePos());
+
+                    if (ImGui.GetIO().KeyShift)
+                    {
+                        railCont.mTranslate = posVec;
+                    }
+                    else
+                    {
+                        posVec.X = MathF.Round(posVec.X * 2, MidpointRounding.AwayFromZero) / 2;
+                        posVec.Y = MathF.Round(posVec.Y * 2, MidpointRounding.AwayFromZero) / 2;
+                        posVec.Z = railCont.mTranslate.Z;
+                        railCont.mTranslate = posVec;
+                    }
+                }
             }
 
 
@@ -814,7 +832,7 @@ namespace Fushigi.ui.widgets
                 }
             }
 
-            if (ImGui.IsMouseDown(0))
+            if (ImGui.IsMouseDown(0) && !isPanGesture)
                 dragRelease = ImGui.IsMouseDragging(0);
 
             if(mHoveredObject != null && 
@@ -837,6 +855,13 @@ namespace Fushigi.ui.widgets
 
             if (ImGui.IsKeyPressed(ImGuiKey.Delete))
                 ObjectDeletionRequested?.Invoke(mEditContext.GetSelectedObjects<CourseActor>().ToList());
+
+            if (mEditContext.IsSingleObjectSelected(out CourseRail.CourseRailPoint? point) &&
+                mHoveredObject == point &&
+                ImGui.IsMouseDoubleClicked(0))
+            {
+                point.mIsCurve = !point.mIsCurve;
+            }
 
             if (ImGui.IsKeyPressed(ImGuiKey.Escape))
                 mEditContext.DeselectAll();
@@ -957,6 +982,7 @@ namespace Fushigi.ui.widgets
                     foreach (var point in rail.mPoints)
                     {
                         var pos2D = this.WorldToScreen(new(point.mTranslate.X, point.mTranslate.Y, point.mTranslate.Z));
+                        var contPos2D = this.WorldToScreen(point.mControl.mTranslate);
                         Vector2 pnt = new(pos2D.X, pos2D.Y);
                         bool isHovered = (ImGui.GetMousePos() - pnt).Length() < 6.0f;
                         if (isHovered)
@@ -964,7 +990,11 @@ namespace Fushigi.ui.widgets
 
                         bool selected = mEditContext.IsSelected(point);
                         if (selected)
+                        {
                             selectedPoint = point;
+                            if ((ImGui.GetMousePos() - contPos2D).Length() < 6.0f)
+                                newHoveredObject = point.mControl;
+                        }
                     }
 
                     //Delete selected
@@ -1034,16 +1064,6 @@ namespace Fushigi.ui.widgets
                     var rail_color = selected ? ImGui.ColorConvertFloat4ToU32(new(1, 1, 0, 1)) : color;
 
                     List<Vector2> pointsList = [];
-                    foreach (CourseRail.CourseRailPoint pnt in rail.mPoints)
-                    {
-                        bool point_selected = mEditContext.IsSelected(pnt);
-                        var rail_point_color = point_selected ? ImGui.ColorConvertFloat4ToU32(new(1, 1, 0, 1)) : color;
-                        var size = newHoveredObject == pnt ? pointSize * 1.5f : pointSize;
-
-                        var pos2D = WorldToScreen(pnt.mTranslate);
-                        mDrawList.AddCircleFilled(pos2D, size, rail_point_color);
-                        pointsList.Add(pos2D);
-                    }
 
                     var segmentCount = rail.mPoints.Count;
                     if (!rail.mIsClosed)
@@ -1061,12 +1081,12 @@ namespace Fushigi.ui.widgets
                         Vector2 cpOutA2D = posA2D;
                         Vector2 cpInB2D = posB2D;
 
-                        if (pointA.mControl.TryGetValue(out Vector3 control))
-                            cpOutA2D = WorldToScreen(control);
+                        if (pointA.mIsCurve)
+                            cpOutA2D = WorldToScreen(pointA.mControl.mTranslate);
 
-                        if (pointB.mControl.TryGetValue(out control))
+                        if (pointB.mIsCurve)
                             //invert control point
-                            cpInB2D = WorldToScreen(pointB.mTranslate - (control - pointB.mTranslate));
+                            cpInB2D = WorldToScreen(pointB.mTranslate - (pointB.mControl.mTranslate - pointB.mTranslate));
 
                         if (cpOutA2D == posA2D && cpInB2D == posB2D)
                         {
@@ -1080,6 +1100,24 @@ namespace Fushigi.ui.widgets
                     float thickness = newHoveredObject == rail ? 3f : 2.5f;
 
                     mDrawList.PathStroke(rail_color, ImDrawFlags.None, thickness);
+
+                    foreach (CourseRail.CourseRailPoint pnt in rail.mPoints)
+                    {
+                        bool point_selected = mEditContext.IsSelected(pnt) || mEditContext.IsSelected(pnt.mControl);
+                        var rail_point_color = point_selected ? ImGui.ColorConvertFloat4ToU32(new(1, 1, 0, 1)) : color;
+                        var size = (newHoveredObject == pnt || newHoveredObject == pnt.mControl) ? pointSize * 1.5f : pointSize;
+
+                        var pos2D = WorldToScreen(pnt.mTranslate);
+                        mDrawList.AddCircleFilled(pos2D, size, rail_point_color, pnt.mIsCurve ? 0:4);
+                        pointsList.Add(pos2D);
+
+                        if (point_selected && pnt.mIsCurve)
+                        {
+                            var contPos2D = WorldToScreen(pnt.mControl.mTranslate);
+                            mDrawList.AddLine(pos2D, contPos2D, rail_point_color, thickness);
+                            mDrawList.AddCircleFilled(contPos2D, size, rail_point_color, 4);
+                        }
+                    }
                 }
             }
 
@@ -1132,7 +1170,8 @@ namespace Fushigi.ui.widgets
 
                     uint color = ImGui.ColorConvertFloat4ToU32(new(0.5f, 1, 0, 1));
 
-                    if (actor.mPackName.Contains("CameraArea") || actor.mActorPack?.Category == "AreaObj")
+                    if (actor.mPackName.Contains("CameraArea") || 
+                        (actor.mActorPack?.Category == "AreaObj" && actor.mActorPack?.ShapeParams == null))
                     {
                         if (actor.mPackName.Contains("CameraArea"))
                             color = ImGui.ColorConvertFloat4ToU32(new(1, 0, 0, 1));

--- a/Fushigi/ui/widgets/LevelViewport.cs
+++ b/Fushigi/ui/widgets/LevelViewport.cs
@@ -560,7 +560,7 @@ namespace Fushigi.ui.widgets
 
             Dictionary<string, Vector3> boneScaleLookup = [];
 
-            foreach (var boneParam in setting.mBoneSetting.BoneInfoList)
+            foreach (var boneParam in setting.mBoneSetting?.BoneInfoList ?? [])
             {
                 Vector2 boneScale;
                 if (boneParam.mIsCustomCalc)
@@ -857,7 +857,7 @@ namespace Fushigi.ui.widgets
 
                 var actors = mEditContext.GetSelectedObjects<CourseActor>().Where(x => x.mTranslation != x.mStartingTrans) ?? [];
 
-                if (actors.Count() > 0)
+                if (actors.Any())
                 {
                     if (mEditContext.IsSingleObjectSelected(out CourseActor? act))
                     {

--- a/Fushigi/ui/widgets/PathSelector.cs
+++ b/Fushigi/ui/widgets/PathSelector.cs
@@ -10,6 +10,8 @@ namespace Fushigi.ui.widgets
     {
         public static bool Show(string label, ref string path, bool isValid = true)
         {
+            bool edited;
+            bool clicked;
             //Ensure path isn't null for imgui
             if (path == null)
                 path = "";
@@ -18,49 +20,50 @@ namespace Fushigi.ui.widgets
             if (!System.IO.Directory.Exists(path))
                 isValid = false;
 
-            ImGui.Columns(2);
-
-            ImGui.SetColumnWidth(0, 150);
-
-            bool edited = false;
-
-            ImGui.Text(label);
-
-            ImGui.NextColumn();
-
-            ImGui.PushItemWidth(ImGui.GetColumnWidth() - 100);
-
-            if (!isValid)
+            ImGui.BeginTable("path", 2, ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.Resizable);
             {
-                ImGui.PushStyleColor(ImGuiCol.FrameBg, new Vector4(0.5f, 0, 0, 1));
-                ImGui.InputText($"##{label}", ref path, 500, ImGuiInputTextFlags.ReadOnly);
-                ImGui.PopStyleColor();
+                ImGui.TableSetupColumn("one", ImGuiTableColumnFlags.WidthFixed, 150.0f);
+                
+                ImGui.TableNextRow();
+                ImGui.TableSetColumnIndex(0);
+                    edited = false;
+
+                    ImGui.Text(label);
+
+                    ImGui.TableNextColumn();
+
+                    ImGui.PushItemWidth(ImGui.GetColumnWidth() - 100);
+
+                    if (!isValid)
+                    {
+                        ImGui.PushStyleColor(ImGuiCol.FrameBg, new Vector4(0.5f, 0, 0, 1));
+                        ImGui.InputText($"##{label}", ref path, 500, ImGuiInputTextFlags.ReadOnly);
+                        ImGui.PopStyleColor();
+                    }
+                    else
+                    {
+                        ImGui.PushStyleColor(ImGuiCol.FrameBg, new Vector4(0, 0.5f, 0, 1));
+                        ImGui.InputText($"##{label}", ref path, 500, ImGuiInputTextFlags.ReadOnly);
+                        ImGui.PopStyleColor();
+                    }
+
+                    if (ImGui.BeginPopupContextItem($"{label}_clear", ImGuiPopupFlags.MouseButtonRight))
+                    {
+                        if (ImGui.MenuItem("Clear"))
+                        {
+                            path = "";
+                            edited = true;
+                        }
+                        ImGui.EndPopup();
+                    }
+
+                    ImGui.PopItemWidth();
+
+                    ImGui.SameLine();
+                    clicked = ImGui.Button($"Select##{label}");
+
+                ImGui.EndTable();
             }
-            else
-            {
-                ImGui.PushStyleColor(ImGuiCol.FrameBg, new Vector4(0, 0.5f, 0, 1));
-                ImGui.InputText($"##{label}", ref path, 500, ImGuiInputTextFlags.ReadOnly);
-                ImGui.PopStyleColor();
-            }
-
-            if (ImGui.BeginPopupContextItem($"{label}_clear", ImGuiPopupFlags.MouseButtonRight))
-            {
-                if (ImGui.MenuItem("Clear"))
-                {
-                    path = "";
-                    edited = true;
-                }
-                ImGui.EndPopup();
-            }
-
-            ImGui.PopItemWidth();
-
-            ImGui.SameLine();
-            bool clicked = ImGui.Button($"Select##{label}");
-
-            ImGui.NextColumn();
-
-            ImGui.Columns(1);
 
             if (clicked)
             {

--- a/Fushigi/util/BymlUtil.cs
+++ b/Fushigi/util/BymlUtil.cs
@@ -62,6 +62,14 @@ namespace Fushigi.util
             vec.Z = GetNodeFromArray<float>(array, 2);
             return vec;
         }
+        public static System.Numerics.Vector3 GetVector3FromHashTable(BymlHashTable? table)
+        {
+            System.Numerics.Vector3 vec = new System.Numerics.Vector3();
+            vec.X = GetNodeData<float>(table["X"]);
+            vec.Y = GetNodeData<float>(table["Y"]);
+            vec.Z = GetNodeData<float>(table["Z"]);
+            return vec;
+        }
         
         public static object GetValueFromDynamicNode(IBymlNode node, ParamDB.ComponentParam param)
         {


### PR DESCRIPTION
### Features
* Curved Rails can be created and their curve control point can be moved in the viewport when a point is selected.
* Overlapping rail points is possible now
* ***Adding layers is now possible*** (limits to the amount of Play/DecoArea layers)
* **WIP** Deleting Layers
### Fixes
* Fixed crash with loading bone params
* Fixed how Actor To Rail Links are saved, as the previous method caused bugs with objects that moved along them automatically.
* Legacy ImGui Column code rewritten with the newer API's ImGui Table code.
* Tweaked the UI of Actor to Rail Link and Local Links window
* Fixed selecting Tile Units, Rails, and Global Links via the UI windows
* Fixed batch undo when deleting multiple objects